### PR TITLE
DP-1546 Use "pkg_resources style" for namespace package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## ?.?.?
+
+* The `okdata` namespace package now uses the old-style `pkg_resources`
+  declaration instead of being an implicit namespace package.
+
 ## 0.7.0
 
 ### Breaking

--- a/okdata/__init__.py
+++ b/okdata/__init__.py
@@ -1,0 +1,1 @@
+__import__("pkg_resources").declare_namespace(__name__)

--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setuptools.setup(
     packages=setuptools.find_namespace_packages(
         include="okdata.cli.*", exclude=["tests*"]
     ),
+    namespace_packages=["okdata"],
     package_data={
         "okdata": [
             "cli/data/boilerplate/bin/*",


### PR DESCRIPTION
Use "pkg_resources style" for the `okdata` namespace package. Modern style implicit namespace packages aren't supported by the Serverless plugin we use for Python packaging yet [1], so we'll use the old `pkg_resources` style for now.

[1] https://github.com/UnitedIncome/serverless-python-requirements/issues/32