### PR TITLE
Offer ready baked Excel to CSV pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## ?.?.?
+
+* A pipeline for transforming Excel to CSV is now offered in the dataset
+  creation wizard.
+
 ## 0.8.0
 
 * The `okdata` namespace package now uses the old-style `pkg_resources`

--- a/okdata/cli/commands/datasets/boilerplate/config.py
+++ b/okdata/cli/commands/datasets/boilerplate/config.py
@@ -10,6 +10,7 @@ from .validator import (
 pipeline_choices = [
     Choice("Lagre dataen slik den er", "data-copy"),
     Choice("Konverter fra CSV til Parquet", "csv-to-parquet"),
+    Choice("Konverter fra Excel til CSV", "pipeline-excel-to-csv"),
     Choice("Ingen prosessering (krever manuell konfigurasjon av pipeline)", False),
 ]
 


### PR DESCRIPTION
Offer the `excel-to-csv` pipeline as a choice in the dataset creation wizard, alongside the existing `data-copy` and `csv-to-parquet` pipelines.

Depends on deployment of:
~~https://github.oslo.kommune.no/origo-dataplatform/dataplatform-config/pull/513~~
~~https://github.oslo.kommune.no/origo-dataplatform/dataplatform-config/pull/514~~
~~https://github.oslo.kommune.no/origo-dataplatform/dataplatform-config/pull/515~~
~~https://github.oslo.kommune.no/origo-dataplatform/dataplatform-config/pull/517~~
~~https://github.oslo.kommune.no/origo-dataplatform/csv-transformer/pull/40~~
~~https://github.oslo.kommune.no/origo-dataplatform/csv-transformer/pull/41~~