### PR TITLE
Bump required `okdata-sdk` version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,7 +21,7 @@ inquirer==2.7.0           # via okdata-cli (setup.py)
 jinja2==2.11.2            # via sphinx
 jsonschema==3.2.0         # via okdata-sdk
 markupsafe==1.1.1         # via jinja2
-okdata-sdk==0.5.0         # via okdata-cli (setup.py)
+okdata-sdk==0.5.2         # via okdata-cli (setup.py)
 packaging==20.4           # via sphinx
 prettytable==0.7.2        # via okdata-cli (setup.py), okdata-sdk
 prompt-toolkit==3.0.7     # via questionary

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
         "Sphinx",
         "docopt",
         "inquirer",
-        "okdata-sdk",
+        "okdata-sdk>=0.5.2",
         "pygments",
         "recommonmark",
         "requests",


### PR DESCRIPTION
Require version 0.5.2 or higher of `okdata-sdk`. This is necessary because of the switch from native namespace packages to the old-style `pkg_resources` method.