### PR TITLE
DP-1556: Add additional metadata fields to wizard (geodata)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## ?.?.?
+
+* Add additional metadata fields to dataset creation wizard.
+
 ## 0.9.0
 
 * A pipeline for transforming Excel to CSV is now offered in the dataset

--- a/okdata/cli/commands/datasets/boilerplate/boilerplate.py
+++ b/okdata/cli/commands/datasets/boilerplate/boilerplate.py
@@ -118,7 +118,7 @@ Options:{BASE_COMMAND_OPTIONS}
                 "email": config.get("email"),
                 "phone": config.get("phone"),
             }
-            data["keywords"] = [x.strip() for x in config["keywords"].split(",")]
+            data["keywords"] = [x.strip() for x in config["keywords"].split(";")]
         with open(dataset_file, "w") as outfile:
             json.dump(data, outfile, indent=4)
 

--- a/okdata/cli/commands/datasets/boilerplate/boilerplate.py
+++ b/okdata/cli/commands/datasets/boilerplate/boilerplate.py
@@ -2,12 +2,11 @@ import os
 import re
 import json
 import shutil
-from questionary import prompt
 
 from okdata.cli.command import BaseCommand, BASE_COMMAND_OPTIONS
 from okdata.cli.date import date_now, DATE_METADATA_EDITION_FORMAT
 
-from .config import available_pipelines, boilerplate_questions
+from .config import available_pipelines, boilerplate_prompt
 
 confidentiality_map = {
     "public": "green",
@@ -54,7 +53,7 @@ Options:{BASE_COMMAND_OPTIONS}
         return name
 
     def read_config_from_user(self):
-        config = prompt(boilerplate_questions)
+        config = boilerplate_prompt(include_extra_metadata=False)
         return config
 
     def get_out_dir(self, name):

--- a/okdata/cli/commands/datasets/boilerplate/boilerplate.py
+++ b/okdata/cli/commands/datasets/boilerplate/boilerplate.py
@@ -118,7 +118,7 @@ Options:{BASE_COMMAND_OPTIONS}
                 "email": config.get("email"),
                 "phone": config.get("phone"),
             }
-            data["keywords"] = [x.strip() for x in config["keywords"].split(";")]
+            data["keywords"] = config["keywords"]
         with open(dataset_file, "w") as outfile:
             json.dump(data, outfile, indent=4)
 

--- a/okdata/cli/commands/datasets/boilerplate/config.py
+++ b/okdata/cli/commands/datasets/boilerplate/config.py
@@ -1,10 +1,13 @@
-from questionary import Choice
+from questionary import Choice, prompt
 
 from .validator import (
     KeywordValidator,
     PhoneValidator,
     SimpleEmailValidator,
     TitleValidator,
+    StandardsValidator,
+    SpatialValidator,
+    SpatialResolutionValidator,
 )
 
 pipeline_choices = [
@@ -16,44 +19,86 @@ pipeline_choices = [
 
 available_pipelines = [c.value for c in pipeline_choices if c.value]
 
-boilerplate_questions = [
-    {"type": "text", "name": "title", "message": "Tittel", "validate": TitleValidator},
-    {"type": "text", "name": "description", "message": "Beskrivelse"},
-    {"type": "text", "name": "objective", "message": "Formål"},
-    {
-        "type": "text",
-        "name": "keywords",
-        "message": "Nøkkelord (komma-separert)",
-        "validate": KeywordValidator,
-    },
-    {
-        "type": "select",
-        "name": "accessRights",
-        "message": "Tilgangsnivå",
-        "choices": [
-            Choice("Offentlig", "public"),
-            Choice("Begrenset offentlighet", "restricted"),
-            Choice("Unntatt offentlighet", "non-public"),
-        ],
-    },
-    {"type": "text", "name": "name", "message": "Kontaktperson - navn"},
-    {
-        "type": "text",
-        "name": "email",
-        "message": "Kontaktperson - epost",
-        "validate": SimpleEmailValidator,
-    },
-    {
-        "type": "text",
-        "name": "phone",
-        "message": "Kontaktperson - telefon",
-        "validate": PhoneValidator,
-    },
-    {"type": "text", "name": "publisher", "message": "Utgiver"},
-    {
-        "type": "select",
-        "name": "pipeline",
-        "message": "Prosessering",
-        "choices": pipeline_choices,
-    },
-]
+
+def boilerplate_prompt(include_extra_metadata=True):
+    boilerplate_questions = [
+        {
+            "type": "text",
+            "name": "title",
+            "message": "Tittel",
+            "validate": TitleValidator,
+        },
+        {"type": "text", "name": "description", "message": "Beskrivelse"},
+        {"type": "text", "name": "objective", "message": "Formål"},
+        {
+            "type": "text",
+            "name": "keywords",
+            "message": "Nøkkelord (komma-separert)",
+            "validate": KeywordValidator,
+        },
+        {
+            "type": "text",
+            "name": "spatial",
+            "message": "Romlig avgrensning (linje-separert)",
+            "multiline": True,
+            "validate": SpatialValidator,
+            "filter": lambda v: [x.strip() for x in v.split("\n") if x],
+            "when": lambda x: include_extra_metadata,
+        },
+        {
+            "type": "text",
+            "name": "spatialResolutionInMeters",
+            "message": "Romlig oppløsning (i meter)",
+            "validate": SpatialResolutionValidator,
+            "filter": lambda v: float(v.replace(",", ".")) if v else None,
+            "when": lambda x: include_extra_metadata,
+        },
+        {
+            "type": "text",
+            "name": "conformsTo",
+            "message": "Standarder (linje-separert)",
+            "multiline": True,
+            "validate": StandardsValidator,
+            "filter": lambda v: [x.strip() for x in v.split("\n") if x],
+            "when": lambda x: include_extra_metadata,
+        },
+        {
+            "type": "select",
+            "name": "accessRights",
+            "message": "Tilgangsnivå",
+            "choices": [
+                Choice("Offentlig", "public"),
+                Choice("Begrenset offentlighet", "restricted"),
+                Choice("Unntatt offentlighet", "non-public"),
+            ],
+        },
+        {
+            "type": "text",
+            "name": "license",
+            "message": "Lisens",
+            "filter": lambda v: v.strip(),
+            "when": lambda x: include_extra_metadata,
+        },
+        {"type": "text", "name": "name", "message": "Kontaktperson - navn"},
+        {
+            "type": "text",
+            "name": "email",
+            "message": "Kontaktperson - epost",
+            "validate": SimpleEmailValidator,
+        },
+        {
+            "type": "text",
+            "name": "phone",
+            "message": "Kontaktperson - telefon",
+            "validate": PhoneValidator,
+        },
+        {"type": "text", "name": "publisher", "message": "Utgiver"},
+        {
+            "type": "select",
+            "name": "pipeline",
+            "message": "Prosessering",
+            "choices": pipeline_choices,
+        },
+    ]
+
+    return prompt(boilerplate_questions)

--- a/okdata/cli/commands/datasets/boilerplate/config.py
+++ b/okdata/cli/commands/datasets/boilerplate/config.py
@@ -1,4 +1,5 @@
 from questionary import Choice, prompt
+from prompt_toolkit.styles import Style
 
 from .validator import (
     KeywordValidator,
@@ -9,6 +10,8 @@ from .validator import (
     SpatialValidator,
     SpatialResolutionValidator,
 )
+
+required_style = Style([("qmark", "fg:red bold")])
 
 pipeline_choices = [
     Choice("Lagre dataen slik den er", "data-copy"),
@@ -24,6 +27,8 @@ def boilerplate_prompt(include_extra_metadata=True):
     boilerplate_questions = [
         {
             "type": "text",
+            "qmark": "*",
+            "style": required_style,
             "name": "title",
             "message": "Tittel",
             "validate": TitleValidator,
@@ -32,6 +37,8 @@ def boilerplate_prompt(include_extra_metadata=True):
         {"type": "text", "name": "objective", "message": "Formål"},
         {
             "type": "text",
+            "qmark": "*",
+            "style": required_style,
             "name": "keywords",
             "message": "Nøkkelord (komma-separert)",
             "validate": KeywordValidator,
@@ -64,6 +71,8 @@ def boilerplate_prompt(include_extra_metadata=True):
         },
         {
             "type": "select",
+            "qmark": "*",
+            "style": required_style,
             "name": "accessRights",
             "message": "Tilgangsnivå",
             "choices": [
@@ -82,12 +91,16 @@ def boilerplate_prompt(include_extra_metadata=True):
         {"type": "text", "name": "name", "message": "Kontaktperson - navn"},
         {
             "type": "text",
+            "qmark": "*",
+            "style": required_style,
             "name": "email",
             "message": "Kontaktperson - epost",
             "validate": SimpleEmailValidator,
         },
         {
             "type": "text",
+            "qmark": "*",
+            "style": required_style,
             "name": "phone",
             "message": "Kontaktperson - telefon",
             "validate": PhoneValidator,
@@ -95,6 +108,8 @@ def boilerplate_prompt(include_extra_metadata=True):
         {"type": "text", "name": "publisher", "message": "Utgiver"},
         {
             "type": "select",
+            "qmark": "*",
+            "style": required_style,
             "name": "pipeline",
             "message": "Prosessering",
             "choices": pipeline_choices,

--- a/okdata/cli/commands/datasets/boilerplate/config.py
+++ b/okdata/cli/commands/datasets/boilerplate/config.py
@@ -44,13 +44,19 @@ def boilerplate_prompt(include_extra_metadata=True):
             "validate": KeywordValidator,
         },
         {
+            "type": "confirm",
+            "name": "contains_geodata",
+            "message": "Inneholder datasettet geodata?",
+            "default": False,
+        },
+        {
             "type": "text",
             "name": "spatial",
             "message": "Romlig avgrensning (linje-separert)",
             "multiline": True,
             "validate": SpatialValidator,
             "filter": lambda v: [x.strip() for x in v.split("\n") if x],
-            "when": lambda x: include_extra_metadata,
+            "when": lambda x: include_extra_metadata and x["contains_geodata"],
         },
         {
             "type": "text",
@@ -58,7 +64,7 @@ def boilerplate_prompt(include_extra_metadata=True):
             "message": "Romlig oppløsning (i meter)",
             "validate": SpatialResolutionValidator,
             "filter": lambda v: float(v.replace(",", ".")) if v else None,
-            "when": lambda x: include_extra_metadata,
+            "when": lambda x: include_extra_metadata and x["contains_geodata"],
         },
         {
             "type": "text",

--- a/okdata/cli/commands/datasets/boilerplate/config.py
+++ b/okdata/cli/commands/datasets/boilerplate/config.py
@@ -48,7 +48,7 @@ def boilerplate_prompt(include_extra_metadata=True):
             "qmark": "*",
             "style": required_style,
             "name": "keywords",
-            "message": "Nøkkelord (semikolon-separert)",
+            "message": "Nøkkelord (komma-separert)",
             "validate": KeywordValidator,
             "filter": filter_comma_separated,
         },
@@ -61,7 +61,7 @@ def boilerplate_prompt(include_extra_metadata=True):
         {
             "type": "text",
             "name": "spatial",
-            "message": "Romlig avgrensning (semikolon-separert)",
+            "message": "Romlig avgrensning (komma-separert)",
             "validate": SpatialValidator,
             "filter": filter_comma_separated,
             "when": lambda x: include_extra_metadata and x["contains_geodata"],
@@ -77,7 +77,7 @@ def boilerplate_prompt(include_extra_metadata=True):
         {
             "type": "text",
             "name": "conformsTo",
-            "message": "I samsvar med standarder (semikolon-separert)",
+            "message": "I samsvar med standarder (komma-separert)",
             "validate": StandardsValidator,
             "filter": filter_comma_separated,
             "when": lambda x: include_extra_metadata,

--- a/okdata/cli/commands/datasets/boilerplate/config.py
+++ b/okdata/cli/commands/datasets/boilerplate/config.py
@@ -28,7 +28,7 @@ def filter_comma_separated(value):
     values = next(
         csv.reader([value], delimiter=",", escapechar="\\", skipinitialspace=True)
     )
-    return [x.strip() for x in values if x.strip()]
+    return [x.strip() for x in values if x]
 
 
 def boilerplate_prompt(include_extra_metadata=True):
@@ -57,6 +57,7 @@ def boilerplate_prompt(include_extra_metadata=True):
             "name": "contains_geodata",
             "message": "Inneholder datasettet geodata?",
             "default": False,
+            "when": lambda x: include_extra_metadata,
         },
         {
             "type": "text",

--- a/okdata/cli/commands/datasets/boilerplate/config.py
+++ b/okdata/cli/commands/datasets/boilerplate/config.py
@@ -40,7 +40,7 @@ def boilerplate_prompt(include_extra_metadata=True):
             "qmark": "*",
             "style": required_style,
             "name": "keywords",
-            "message": "Nøkkelord (komma-separert)",
+            "message": "Nøkkelord (semikolon-separert)",
             "validate": KeywordValidator,
         },
         {

--- a/okdata/cli/commands/datasets/boilerplate/config.py
+++ b/okdata/cli/commands/datasets/boilerplate/config.py
@@ -52,10 +52,9 @@ def boilerplate_prompt(include_extra_metadata=True):
         {
             "type": "text",
             "name": "spatial",
-            "message": "Romlig avgrensning (linje-separert)",
-            "multiline": True,
+            "message": "Romlig avgrensning (semikolon-separert)",
             "validate": SpatialValidator,
-            "filter": lambda v: [x.strip() for x in v.split("\n") if x],
+            "filter": lambda v: [x.strip() for x in v.split(";") if x.strip()],
             "when": lambda x: include_extra_metadata and x["contains_geodata"],
         },
         {
@@ -69,10 +68,9 @@ def boilerplate_prompt(include_extra_metadata=True):
         {
             "type": "text",
             "name": "conformsTo",
-            "message": "Standarder (linje-separert)",
-            "multiline": True,
+            "message": "I samsvar med standarder (semikolon-separert)",
             "validate": StandardsValidator,
-            "filter": lambda v: [x.strip() for x in v.split("\n") if x],
+            "filter": lambda v: [x.strip() for x in v.split(";") if x.strip()],
             "when": lambda x: include_extra_metadata,
         },
         {

--- a/okdata/cli/commands/datasets/boilerplate/config.py
+++ b/okdata/cli/commands/datasets/boilerplate/config.py
@@ -50,7 +50,7 @@ def boilerplate_prompt(include_extra_metadata=True):
             "name": "keywords",
             "message": "Nøkkelord (semikolon-separert)",
             "validate": KeywordValidator,
-            "filter": lambda v: filter_comma_separated(v),
+            "filter": filter_comma_separated,
         },
         {
             "type": "confirm",
@@ -63,7 +63,7 @@ def boilerplate_prompt(include_extra_metadata=True):
             "name": "spatial",
             "message": "Romlig avgrensning (semikolon-separert)",
             "validate": SpatialValidator,
-            "filter": lambda v: filter_comma_separated(v),
+            "filter": filter_comma_separated,
             "when": lambda x: include_extra_metadata and x["contains_geodata"],
         },
         {
@@ -79,7 +79,7 @@ def boilerplate_prompt(include_extra_metadata=True):
             "name": "conformsTo",
             "message": "I samsvar med standarder (semikolon-separert)",
             "validate": StandardsValidator,
-            "filter": lambda v: filter_comma_separated(v),
+            "filter": filter_comma_separated,
             "when": lambda x: include_extra_metadata,
         },
         {

--- a/okdata/cli/commands/datasets/boilerplate/config.py
+++ b/okdata/cli/commands/datasets/boilerplate/config.py
@@ -1,3 +1,4 @@
+import csv
 from questionary import Choice, prompt
 from prompt_toolkit.styles import Style
 
@@ -23,6 +24,13 @@ pipeline_choices = [
 available_pipelines = [c.value for c in pipeline_choices if c.value]
 
 
+def filter_comma_separated(value):
+    values = next(
+        csv.reader([value], delimiter=",", escapechar="\\", skipinitialspace=True)
+    )
+    return [x.strip() for x in values if x.strip()]
+
+
 def boilerplate_prompt(include_extra_metadata=True):
     boilerplate_questions = [
         {
@@ -42,6 +50,7 @@ def boilerplate_prompt(include_extra_metadata=True):
             "name": "keywords",
             "message": "Nøkkelord (semikolon-separert)",
             "validate": KeywordValidator,
+            "filter": lambda v: filter_comma_separated(v),
         },
         {
             "type": "confirm",
@@ -54,7 +63,7 @@ def boilerplate_prompt(include_extra_metadata=True):
             "name": "spatial",
             "message": "Romlig avgrensning (semikolon-separert)",
             "validate": SpatialValidator,
-            "filter": lambda v: [x.strip() for x in v.split(";") if x.strip()],
+            "filter": lambda v: filter_comma_separated(v),
             "when": lambda x: include_extra_metadata and x["contains_geodata"],
         },
         {
@@ -70,7 +79,7 @@ def boilerplate_prompt(include_extra_metadata=True):
             "name": "conformsTo",
             "message": "I samsvar med standarder (semikolon-separert)",
             "validate": StandardsValidator,
-            "filter": lambda v: [x.strip() for x in v.split(";") if x.strip()],
+            "filter": lambda v: filter_comma_separated(v),
             "when": lambda x: include_extra_metadata,
         },
         {

--- a/okdata/cli/commands/datasets/boilerplate/validator.py
+++ b/okdata/cli/commands/datasets/boilerplate/validator.py
@@ -70,9 +70,9 @@ class KeywordValidator(Validator):
 
 class StandardsValidator(Validator):
     def validate(self, document):
-        standards = [x.strip() for x in document.text.split("\n")]
-        if len([x for x in standards if x]) == 0:
+        if not document.text.strip():
             return True
+        standards = [x.strip() for x in document.text.split(";")]
         for standard in standards:
             standard = standard.strip()
             if len(standard) < 3:
@@ -89,9 +89,9 @@ class StandardsValidator(Validator):
 
 class SpatialValidator(Validator):
     def validate(self, document):
-        locations = [x.strip() for x in document.text.split("\n")]
-        if len([x for x in locations if x]) == 0:
+        if not document.text.strip():
             return True
+        locations = [x.strip() for x in document.text.split(";")]
         for location in locations:
             location = location.strip()
             if len(location) < 1:

--- a/okdata/cli/commands/datasets/boilerplate/validator.py
+++ b/okdata/cli/commands/datasets/boilerplate/validator.py
@@ -1,5 +1,6 @@
-import datetime
 import re
+import csv
+import datetime
 
 from questionary import Validator, ValidationError
 
@@ -50,31 +51,31 @@ class TitleValidator(Validator):
 
 class KeywordValidator(Validator):
     def validate(self, document):
-        keywords = [x.strip() for x in document.text.split(";")]
-        if len(keywords) == 0:
-            return True
+        keywords = csv.reader(
+            [document.text], delimiter=",", escapechar="\\", skipinitialspace=True
+        )
+        keywords = [x.strip() for x in next(keywords)]
         have_valid_keywords = False
         for keyword in keywords:
-            keyword = keyword.strip()
             if len(keyword) >= 3:
                 have_valid_keywords = True
             else:
                 have_valid_keywords = False
                 break
-        if have_valid_keywords is False:
+        if have_valid_keywords is False or len(keywords) != len(set(keywords)):
             raise ValidationError(
-                message="At least one keyword, each must be at least 3 characters",
+                message="At least one keyword, each must be unique and at least 3 characters",
                 cursor_position=len(document.text),
             )
 
 
 class StandardsValidator(Validator):
     def validate(self, document):
-        if not document.text.strip():
-            return True
-        standards = [x.strip() for x in document.text.split(";")]
+        standards = csv.reader(
+            [document.text], delimiter=",", escapechar="\\", skipinitialspace=True
+        )
+        standards = [x.strip() for x in next(standards)]
         for standard in standards:
-            standard = standard.strip()
             if len(standard) < 3:
                 raise ValidationError(
                     message="Each standard reference must be at least 3 characters",
@@ -89,11 +90,11 @@ class StandardsValidator(Validator):
 
 class SpatialValidator(Validator):
     def validate(self, document):
-        if not document.text.strip():
-            return True
-        locations = [x.strip() for x in document.text.split(";")]
+        locations = csv.reader(
+            [document.text], delimiter=",", escapechar="\\", skipinitialspace=True
+        )
+        locations = [x.strip() for x in next(locations)]
         for location in locations:
-            location = location.strip()
             if len(location) < 1:
                 raise ValidationError(
                     message="Each location must be at least 1 character",

--- a/okdata/cli/commands/datasets/boilerplate/validator.py
+++ b/okdata/cli/commands/datasets/boilerplate/validator.py
@@ -55,14 +55,8 @@ class KeywordValidator(Validator):
             [document.text], delimiter=",", escapechar="\\", skipinitialspace=True
         )
         keywords = [x.strip() for x in next(keywords)]
-        have_valid_keywords = False
-        for keyword in keywords:
-            if len(keyword) >= 3:
-                have_valid_keywords = True
-            else:
-                have_valid_keywords = False
-                break
-        if have_valid_keywords is False or len(keywords) != len(set(keywords)):
+        have_valid_keywords = keywords and all([len(k) >= 3 for k in keywords])
+        if not have_valid_keywords or len(keywords) != len(set(keywords)):
             raise ValidationError(
                 message="At least one keyword, each must be unique and at least 3 characters",
                 cursor_position=len(document.text),

--- a/okdata/cli/commands/datasets/boilerplate/validator.py
+++ b/okdata/cli/commands/datasets/boilerplate/validator.py
@@ -50,7 +50,7 @@ class TitleValidator(Validator):
 
 class KeywordValidator(Validator):
     def validate(self, document):
-        keywords = [x.strip() for x in document.text.split(",")]
+        keywords = [x.strip() for x in document.text.split(";")]
         if len(keywords) == 0:
             return True
         have_valid_keywords = False

--- a/okdata/cli/commands/datasets/boilerplate/validator.py
+++ b/okdata/cli/commands/datasets/boilerplate/validator.py
@@ -66,3 +66,56 @@ class KeywordValidator(Validator):
                 message="At least one keyword, each must be at least 3 characters",
                 cursor_position=len(document.text),
             )
+
+
+class StandardsValidator(Validator):
+    def validate(self, document):
+        standards = [x.strip() for x in document.text.split("\n")]
+        if len([x for x in standards if x]) == 0:
+            return True
+        for standard in standards:
+            standard = standard.strip()
+            if len(standard) < 3:
+                raise ValidationError(
+                    message="Each standard reference must be at least 3 characters",
+                    cursor_position=len(document.text),
+                )
+        if len(standards) != len(set(standards)):
+            raise ValidationError(
+                message="Each standard reference must be unique",
+                cursor_position=len(document.text),
+            )
+
+
+class SpatialValidator(Validator):
+    def validate(self, document):
+        locations = [x.strip() for x in document.text.split("\n")]
+        if len([x for x in locations if x]) == 0:
+            return True
+        for location in locations:
+            location = location.strip()
+            if len(location) < 1:
+                raise ValidationError(
+                    message="Each location must be at least 1 character",
+                    cursor_position=len(document.text),
+                )
+        if len(locations) != len(set(locations)):
+            raise ValidationError(
+                message="Each location must be unique",
+                cursor_position=len(document.text),
+            )
+
+
+class SpatialResolutionValidator(Validator):
+    def validate(self, document):
+        if not document.text:
+            return True
+        try:
+            number = float(document.text.replace(",", "."))
+            if number <= 0:
+                raise ValueError
+        except ValueError:
+            raise ValidationError(
+                message="Please enter a positive (decimal) number",
+                cursor_position=len(document.text),
+            )

--- a/okdata/cli/commands/datasets/wizards.py
+++ b/okdata/cli/commands/datasets/wizards.py
@@ -22,7 +22,7 @@ class DatasetCreateWizard:
         config = {
             "title": title,
             "description": choices["description"] or title,
-            "keywords": choices["keywords"].split(";"),
+            "keywords": choices["keywords"],
             "accessRights": access_rights,
             "confidentiality": confidentiality_map[access_rights],
             "objective": choices["objective"] or title,

--- a/okdata/cli/commands/datasets/wizards.py
+++ b/okdata/cli/commands/datasets/wizards.py
@@ -1,9 +1,8 @@
 from okdata.sdk.data.dataset import Dataset
 from okdata.sdk.pipelines.client import PipelineApiClient
-from questionary import prompt
 
 from okdata.cli.commands.datasets.boilerplate.boilerplate import confidentiality_map
-from okdata.cli.commands.datasets.boilerplate.config import boilerplate_questions
+from okdata.cli.commands.datasets.boilerplate.config import boilerplate_prompt
 
 
 class DatasetCreateWizard:
@@ -20,7 +19,7 @@ class DatasetCreateWizard:
         title = choices["title"]
         access_rights = choices["accessRights"]
 
-        return {
+        config = {
             "title": title,
             "description": choices["description"] or title,
             "keywords": choices["keywords"].split(","),
@@ -34,6 +33,17 @@ class DatasetCreateWizard:
             },
             "publisher": choices["publisher"],
         }
+
+        if choices.get("spatial"):
+            config["spatial"] = choices["spatial"]
+        if choices.get("spatialResolutionInMeters"):
+            config["spatialResolutionInMeters"] = choices["spatialResolutionInMeters"]
+        if choices.get("conformsTo"):
+            config["conformsTo"] = choices["conformsTo"]
+        if choices.get("license"):
+            config["license"] = choices["license"]
+
+        return config
 
     def pipeline_config(self, pipeline_processor_id, dataset_id, version):
         return {
@@ -51,7 +61,7 @@ class DatasetCreateWizard:
 
     def start(self):
         env = self.command.opt("env")
-        choices = prompt(boilerplate_questions)
+        choices = boilerplate_prompt()
 
         self.command.print("Creating dataset...")
         dataset_client = Dataset(env=env)

--- a/okdata/cli/commands/datasets/wizards.py
+++ b/okdata/cli/commands/datasets/wizards.py
@@ -22,7 +22,7 @@ class DatasetCreateWizard:
         config = {
             "title": title,
             "description": choices["description"] or title,
-            "keywords": choices["keywords"].split(","),
+            "keywords": choices["keywords"].split(";"),
             "accessRights": access_rights,
             "confidentiality": confidentiality_map[access_rights],
             "objective": choices["objective"] or title,

--- a/tests/origocli/commands/datasets/boilerplate/filter_test.py
+++ b/tests/origocli/commands/datasets/boilerplate/filter_test.py
@@ -1,0 +1,53 @@
+from okdata.cli.commands.datasets.boilerplate.config import filter_comma_separated
+
+
+class TestCommaSeparatedFilter:
+    def test_quoted_separator(self):
+        filtered = filter_comma_separated('"ab, c","og d')
+        assert len(filtered) == 2
+        assert filtered[0] == "ab, c"
+
+        filtered = filter_comma_separated(
+            r"EUREF89 NTM Sone 22\, 2d + NN54,"
+            "http://www.opengis.net/def/crs/EPSG/0/5972,"
+            "https://epsg.io/4326"
+        )
+        assert len(filtered) == 3
+        assert filtered[0] == "EUREF89 NTM Sone 22, 2d + NN54"
+
+    def test_initial_space(self):
+        filtered = filter_comma_separated('oslo 1, oslo 2, "oslo 3, vestsiden"')
+        assert len(filtered) == 3
+        assert filtered[2] == "oslo 3, vestsiden"
+
+    def test_escaped_separator(self):
+        filtered = filter_comma_separated(r"a\,b, c, og d")
+        assert len(filtered) == 3
+        assert filtered[0] == "a,b"
+
+        filtered = filter_comma_separated(r'"a\,b", c, og d')
+        assert len(filtered) == 3
+        assert filtered[0] == "a,b"
+
+        filtered = filter_comma_separated(
+            r'"EUREF89 NTM Sone 22, 2d + NN54",'
+            "http://www.opengis.net/def/crs/EPSG/0/5972,"
+            "https://epsg.io/4326"
+        )
+        assert len(filtered) == 3
+        assert filtered[0] == "EUREF89 NTM Sone 22, 2d + NN54"
+
+    def test_stripping(self):
+        filtered = filter_comma_separated(",, ,")
+        assert len(filtered) == 0
+
+        filtered = filter_comma_separated(",,a,")
+        assert len(filtered) == 1
+
+        filtered = filter_comma_separated(',,"",')
+        assert len(filtered) == 0
+
+        filtered = filter_comma_separated(" a,  b  ,")
+        assert len(filtered) == 2
+        assert filtered[0] == "a"
+        assert filtered[1] == "b"

--- a/tests/origocli/commands/datasets/boilerplate/validator_test.py
+++ b/tests/origocli/commands/datasets/boilerplate/validator_test.py
@@ -120,26 +120,28 @@ class TestStandardsValidator:
 
     def test_valid(self):
         self.validate_document({"text": "abc"})
+        self.validate_document({"text": "abc;defg"})
         self.validate_document({"text": "http://www.opengis.net/def/crs/EPSG/0/5972"})
-        self.validate_document({"text": "abc\ndefg"})
+        self.validate_document(
+            {"text": "http://www.opengis.net/def/crs/EPSG/0/5972;https://epsg.io/4326"}
+        )
 
     def test_empty(self):
         self.validate_document({"text": ""})
-        self.validate_document({"text": "\n\n\n"})
 
     def test_min_length(self):
         with pytest.raises(ValidationError):
             self.validate_document({"text": "a"})
         with pytest.raises(ValidationError):
-            self.validate_document({"text": "a\n\nc\nd"})
+            self.validate_document({"text": "a;;c;d"})
         with pytest.raises(ValidationError):
-            self.validate_document({"text": "\n\nc\nd"})
+            self.validate_document({"text": ";;c;d"})
 
     def test_one_invalid_and_one_valid_value(self):
         with pytest.raises(ValidationError):
-            self.validate_document({"text": "a\nstandarddokument"})
+            self.validate_document({"text": "a;standarddokument"})
         with pytest.raises(ValidationError):
-            self.validate_document({"text": "standarddokument\nab"})
+            self.validate_document({"text": "standarddokument;ab"})
 
 
 class TestSpatialValidator:
@@ -150,17 +152,16 @@ class TestSpatialValidator:
 
     def test_valid(self):
         self.validate_document({"text": "Oslo"})
-        self.validate_document({"text": "Oslo Bydel 1\nOslo Bydel 2"})
+        self.validate_document({"text": "Oslo Bydel 1;Oslo Bydel 2"})
 
     def test_empty(self):
         self.validate_document({"text": ""})
-        self.validate_document({"text": "\n\n\n"})
 
     def test_one_invalid_and_one_valid_value(self):
         with pytest.raises(ValidationError):
-            self.validate_document({"text": "Å\n"})
+            self.validate_document({"text": "Å;"})
         with pytest.raises(ValidationError):
-            self.validate_document({"text": "\nÅs"})
+            self.validate_document({"text": ";Ås"})
 
 
 class TestSpatialResolutionValidator:

--- a/tests/origocli/commands/datasets/boilerplate/validator_test.py
+++ b/tests/origocli/commands/datasets/boilerplate/validator_test.py
@@ -97,15 +97,15 @@ class TestKeywordValidator:
 
     def test_too_short_keywords(self):
         with pytest.raises(ValidationError):
-            self.validate_keywords({"text": "ab, cd"})
+            self.validate_keywords({"text": "ab; cd"})
 
     def test_one_valid_and_one_invalid_keyword(self):
         with pytest.raises(ValidationError):
-            self.validate_keywords({"text": "abc, cd"})
+            self.validate_keywords({"text": "abc; cd"})
 
     def test_one_invalid_and_one_valid_keyword(self):
         with pytest.raises(ValidationError):
-            self.validate_keywords({"text": "cd, abc"})
+            self.validate_keywords({"text": "cd; abc"})
 
     def test_empty_keywords(self):
         with pytest.raises(ValidationError):

--- a/tests/origocli/commands/datasets/boilerplate/validator_test.py
+++ b/tests/origocli/commands/datasets/boilerplate/validator_test.py
@@ -97,15 +97,15 @@ class TestKeywordValidator:
 
     def test_too_short_keywords(self):
         with pytest.raises(ValidationError):
-            self.validate_keywords({"text": "ab; cd"})
+            self.validate_keywords({"text": "ab, cd"})
 
     def test_one_valid_and_one_invalid_keyword(self):
         with pytest.raises(ValidationError):
-            self.validate_keywords({"text": "abc; cd"})
+            self.validate_keywords({"text": "abc, cd"})
 
     def test_one_invalid_and_one_valid_keyword(self):
         with pytest.raises(ValidationError):
-            self.validate_keywords({"text": "cd; abc"})
+            self.validate_keywords({"text": "cd, abc"})
 
     def test_empty_keywords(self):
         with pytest.raises(ValidationError):
@@ -120,10 +120,11 @@ class TestStandardsValidator:
 
     def test_valid(self):
         self.validate_document({"text": "abc"})
-        self.validate_document({"text": "abc;defg"})
+        self.validate_document({"text": "abc,defg"})
+        self.validate_document({"text": r"a\,bc,defg"})
         self.validate_document({"text": "http://www.opengis.net/def/crs/EPSG/0/5972"})
         self.validate_document(
-            {"text": "http://www.opengis.net/def/crs/EPSG/0/5972;https://epsg.io/4326"}
+            {"text": "http://www.opengis.net/def/crs/EPSG/0/5972,https://epsg.io/4326"}
         )
 
     def test_empty(self):
@@ -133,15 +134,15 @@ class TestStandardsValidator:
         with pytest.raises(ValidationError):
             self.validate_document({"text": "a"})
         with pytest.raises(ValidationError):
-            self.validate_document({"text": "a;;c;d"})
+            self.validate_document({"text": "a,,c,d"})
         with pytest.raises(ValidationError):
-            self.validate_document({"text": ";;c;d"})
+            self.validate_document({"text": ",,c,d"})
 
     def test_one_invalid_and_one_valid_value(self):
         with pytest.raises(ValidationError):
-            self.validate_document({"text": "a;standarddokument"})
+            self.validate_document({"text": "a,standarddokument"})
         with pytest.raises(ValidationError):
-            self.validate_document({"text": "standarddokument;ab"})
+            self.validate_document({"text": "standarddokument,ab"})
 
 
 class TestSpatialValidator:
@@ -152,16 +153,17 @@ class TestSpatialValidator:
 
     def test_valid(self):
         self.validate_document({"text": "Oslo"})
-        self.validate_document({"text": "Oslo Bydel 1;Oslo Bydel 2"})
+        self.validate_document({"text": "Oslo Bydel 1,Oslo Bydel 2"})
+        self.validate_document({"text": '"Oslo Bydel 1, Vest",Oslo Bydel 2'})
 
     def test_empty(self):
         self.validate_document({"text": ""})
 
     def test_one_invalid_and_one_valid_value(self):
         with pytest.raises(ValidationError):
-            self.validate_document({"text": "Å;"})
+            self.validate_document({"text": "Å,"})
         with pytest.raises(ValidationError):
-            self.validate_document({"text": ";Ås"})
+            self.validate_document({"text": ",Ås"})
 
 
 class TestSpatialResolutionValidator:

--- a/tests/origocli/commands/datasets/boilerplate/validator_test.py
+++ b/tests/origocli/commands/datasets/boilerplate/validator_test.py
@@ -8,6 +8,9 @@ from okdata.cli.commands.datasets.boilerplate.validator import (
     PhoneValidator,
     SimpleEmailValidator,
     TitleValidator,
+    StandardsValidator,
+    SpatialValidator,
+    SpatialResolutionValidator,
 )
 
 # Note: no testing of return values since the validator is only
@@ -107,3 +110,81 @@ class TestKeywordValidator:
     def test_empty_keywords(self):
         with pytest.raises(ValidationError):
             self.validate_keywords({"text": ""})
+
+
+class TestStandardsValidator:
+    def validate_document(self, data):
+        validator = StandardsValidator()
+        document = SimpleNamespace(**data)
+        validator.validate(document)
+
+    def test_valid(self):
+        self.validate_document({"text": "abc"})
+        self.validate_document({"text": "http://www.opengis.net/def/crs/EPSG/0/5972"})
+        self.validate_document({"text": "abc\ndefg"})
+
+    def test_empty(self):
+        self.validate_document({"text": ""})
+        self.validate_document({"text": "\n\n\n"})
+
+    def test_min_length(self):
+        with pytest.raises(ValidationError):
+            self.validate_document({"text": "a"})
+        with pytest.raises(ValidationError):
+            self.validate_document({"text": "a\n\nc\nd"})
+        with pytest.raises(ValidationError):
+            self.validate_document({"text": "\n\nc\nd"})
+
+    def test_one_invalid_and_one_valid_value(self):
+        with pytest.raises(ValidationError):
+            self.validate_document({"text": "a\nstandarddokument"})
+        with pytest.raises(ValidationError):
+            self.validate_document({"text": "standarddokument\nab"})
+
+
+class TestSpatialValidator:
+    def validate_document(self, data):
+        validator = SpatialValidator()
+        document = SimpleNamespace(**data)
+        validator.validate(document)
+
+    def test_valid(self):
+        self.validate_document({"text": "Oslo"})
+        self.validate_document({"text": "Oslo Bydel 1\nOslo Bydel 2"})
+
+    def test_empty(self):
+        self.validate_document({"text": ""})
+        self.validate_document({"text": "\n\n\n"})
+
+    def test_one_invalid_and_one_valid_value(self):
+        with pytest.raises(ValidationError):
+            self.validate_document({"text": "Å\n"})
+        with pytest.raises(ValidationError):
+            self.validate_document({"text": "\nÅs"})
+
+
+class TestSpatialResolutionValidator:
+    def validate_document(self, data):
+        validator = SpatialResolutionValidator()
+        document = SimpleNamespace(**data)
+        validator.validate(document)
+
+    def test_valid_numbers(self):
+        self.validate_document({"text": "1"})
+        self.validate_document({"text": "1.234"})
+        self.validate_document({"text": "1,234"})
+        self.validate_document({"text": "0,234"})
+
+    def test_invalid_separator(self):
+        with pytest.raises(ValidationError):
+            self.validate_document({"text": "1-234"})
+
+    def test_gt_zero(self):
+        with pytest.raises(ValidationError):
+            self.validate_document({"text": "0"})
+        with pytest.raises(ValidationError):
+            self.validate_document({"text": "-1.2"})
+
+    def test_invalid_value(self):
+        with pytest.raises(ValidationError):
+            self.validate_document({"text": "ukjent"})


### PR DESCRIPTION
Adds new metadata fields (`spatial`, `spatialResolutionInMeters`, `conformsTo`, `license`) to the dataset creation wizard. The boilerplate wizard is currently kept as is for now. Also added styling for (what the wizard considers) required choices.