### PR TITLE
DP-1633 Remove usage of `confidentiality`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * Add additional metadata fields to dataset creation wizard.
 
+* The `confidentiality` metadata field is now fully replaced by `accessRights`.
+
 ## 0.9.0
 
 * A pipeline for transforming Excel to CSV is now offered in the dataset

--- a/doc/datasets.md
+++ b/doc/datasets.md
@@ -58,7 +58,6 @@ File: `dataset.json`
     "description": "My dataset description",
     "keywords": ["keyword", "for-indexing"],
     "accessRights": "public",
-    "confidentiality": "green",
     "objective": "The objective for this dataset",
     "contactPoint": {
         "name": "Contact Name",
@@ -89,7 +88,6 @@ File: `dataset_with_parent.json`
     "description": "My dataset description",
     "keywords": ["keyword", "for-indexing"],
     "accessRights": "public",
-    "confidentiality": "green",
     "objective": "The objective for this dataset",
     "contactPoint": {
         "name": "Contact Name",

--- a/okdata/cli/commands/datasets/boilerplate/boilerplate.py
+++ b/okdata/cli/commands/datasets/boilerplate/boilerplate.py
@@ -8,12 +8,6 @@ from okdata.cli.date import date_now, DATE_METADATA_EDITION_FORMAT
 
 from .config import available_pipelines, boilerplate_prompt
 
-confidentiality_map = {
-    "public": "green",
-    "restricted": "yellow",
-    "non-public": "red",
-}
-
 
 class DatasetsBoilerplateCommand(BaseCommand):
     __doc__ = f"""
@@ -111,7 +105,6 @@ Options:{BASE_COMMAND_OPTIONS}
             data["objective"] = config.get("objective") or title
             access_rights = config.get("accessRights")
             data["accessRights"] = access_rights
-            data["confidentiality"] = confidentiality_map[access_rights]
             data["publisher"] = config.get("publisher")
             data["contactPoint"] = {
                 "name": config.get("name"),

--- a/okdata/cli/commands/datasets/wizards.py
+++ b/okdata/cli/commands/datasets/wizards.py
@@ -1,7 +1,6 @@
 from okdata.sdk.data.dataset import Dataset
 from okdata.sdk.pipelines.client import PipelineApiClient
 
-from okdata.cli.commands.datasets.boilerplate.boilerplate import confidentiality_map
 from okdata.cli.commands.datasets.boilerplate.config import boilerplate_prompt
 
 
@@ -24,7 +23,6 @@ class DatasetCreateWizard:
             "description": choices["description"] or title,
             "keywords": choices["keywords"],
             "accessRights": access_rights,
-            "confidentiality": confidentiality_map[access_rights],
             "objective": choices["objective"] or title,
             "contactPoint": {
                 "name": choices["name"],

--- a/okdata/cli/data/boilerplate/bin/run.sh
+++ b/okdata/cli/data/boilerplate/bin/run.sh
@@ -36,7 +36,7 @@ dataset_data=`cat $dataset_file`
 if [[ $dataset_data =~ "boilerplate" || $dataset_data =~ "my.address@example.org" || $dataset_data =~ "Publisher Name" ]]
 then
    echo "Error: $dataset_file has not been updated correctly - please change the data to represent the dataset you want to create and the organization creating it!"
-   echo "Note: Change all occurence of 'boilerplate', confidentiality can be 'green', 'yellow' or 'red', contact and publisher must be a real contact point"
+   echo "Note: Change all occurence of 'boilerplate', contact and publisher must be a real contact point"
    exit
 fi
 

--- a/okdata/cli/data/boilerplate/dataset/dataset.json
+++ b/okdata/cli/data/boilerplate/dataset/dataset.json
@@ -3,7 +3,6 @@
     "description": "Describe the boilerplate test",
     "keywords": ["boilerplate", "test"],
     "accessRights": "restricted",
-    "confidentiality": "confidentiality",
     "objective": "The objective for this boilerplate",
     "contactPoint": {
         "name": "Contact Name",

--- a/okdata/cli/data/output-format/events_stream_config.json
+++ b/okdata/cli/data/output-format/events_stream_config.json
@@ -7,9 +7,9 @@
       "name": "Raw",
       "key": "create_raw"
   },
-  "Confidentiality": {
-      "name": "Confidentiality",
-      "key": "confidentiality"
+  "AccessRights": {
+      "name": "Access rights",
+      "key": "accessRights"
   },
   "Deleted": {
       "name": "Deleted",

--- a/tests/origocli/commands/datasets/datasets_test.py
+++ b/tests/origocli/commands/datasets/datasets_test.py
@@ -13,7 +13,7 @@ DATASETS_QUAL = f"{Dataset.__module__}.{Dataset.__name__}"
 dataset = {
     "theme": ["Befolkning og samfunn", "Helse"],
     "publisher": "BBJ (Bydel Bjerke)",
-    "confidentiality": "green",
+    "accessRights": "public",
     "frequency": "Uregelmessig",
     "keywords": [],
     "contactPoint": {"email": "test@test.test"},

--- a/tests/origocli/commands/events_test.py
+++ b/tests/origocli/commands/events_test.py
@@ -18,7 +18,7 @@ event_stream_item = {
     "id": f"{dataset_id}/{version}",
     "create_raw": True,
     "deleted": False,
-    "confidentiality": "yellow",
+    "accessRights": "restricted",
 }
 subscribable_item = {
     "status": "INACTIVE",


### PR DESCRIPTION
Depends on deployment of https://github.oslo.kommune.no/origo-dataplatform/metadata-api/pull/122 and https://github.oslo.kommune.no/origo-dataplatform/event-stream-api/pull/53.