### PR TITLE
DP-1777 Don't lowercase dataset URIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## ?.?.?
+
+* Fixed a bug where event stream creation would result in a "Forbidden" error.
+
 ## 0.10.2
 
 * The dataset source type is now selected in the dataset creation wizard.

--- a/okdata/cli/commands/events.py
+++ b/okdata/cli/commands/events.py
@@ -201,11 +201,11 @@ Options:{BASE_COMMAND_OPTIONS}
             self.print(f"Events for {dataset_id}", out)
 
     def _resolve_dataset_uri(self):
-        dataset_uri = self.arg("dataset-uri").lower()
+        dataset_uri = self.arg("dataset-uri")
         uri_pattern = r"""
             ^                           # beginning of string
             (?:ds:)?                    # match optional "ds:" prefix (non-capturing group)
-            ([a-z0-9\-]+)               # match and capture dataset id; one or more characters in range a-z/0-9, and "-"
+            ([a-zA-Z0-9\-]+)            # match and capture dataset id; one or more characters in range a-z/A-Z/0-9, and "-"
             (?:\/                       # match optional dataset version (non-capturing group, exclude leading "/")
                 ([1-9]|[1-9][0-9]+)         # match and capture digits > 1 (if present)
             )?
@@ -220,6 +220,6 @@ Options:{BASE_COMMAND_OPTIONS}
 
         [dataset_id, version] = match.groups()
 
-        version = version if version else "1"
+        version = version or "1"
 
         return dataset_id, version

--- a/tests/origocli/commands/events_test.py
+++ b/tests/origocli/commands/events_test.py
@@ -167,10 +167,11 @@ def test_resolve_dataset_uri():
         "ds:dette-er-1-test/10",
         "ds:dataset-0-100-x-test/1",
         "ds:mange-versjoner/192",
+        "ds:mIxEd-CaSe/1",
     ]:
         cmd.args["<dataset-uri>"] = dataset_uri
         expected_dataset_id, _, expected_version = dataset_uri[3:].partition("/")
-        expected_version = expected_version if expected_version else "1"
+        expected_version = expected_version or "1"
         assert cmd._resolve_dataset_uri() == (expected_dataset_id, expected_version)
 
 
@@ -185,10 +186,11 @@ def test_resolve_dataset_uri_unprefixed():
         "dette-er-1-test/10",
         "dataset-0-100-x-test/1",
         "mange-versjoner/192",
+        "mIxEd-CaSe/1",
     ]:
         cmd.args["<dataset-uri>"] = dataset_uri
         expected_dataset_id, _, expected_version = dataset_uri.partition("/")
-        expected_version = expected_version if expected_version else "1"
+        expected_version = expected_version or "1"
         assert cmd._resolve_dataset_uri() == (expected_dataset_id, expected_version)
 
 


### PR DESCRIPTION
Dataset URIs are case sensitive, so don't lowercase them when parsing their parts.