### PR TITLE
Raise required okdata-sdk version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,51 +4,120 @@
 #
 #    pip-compile
 #
-alabaster==0.7.12         # via sphinx
-attrs==20.1.0             # via jsonschema
-babel==2.8.0              # via sphinx
-blessed==1.17.6           # via inquirer
-certifi==2020.6.20        # via requests
-chardet==3.0.4            # via requests
-commonmark==0.9.1         # via recommonmark
-docopt==0.6.2             # via okdata-cli (setup.py)
-docutils==0.16            # via recommonmark, sphinx
-ecdsa==0.14.1             # via python-jose
-idna==2.10                # via requests
-imagesize==1.2.0          # via sphinx
-inquirer==2.7.0           # via okdata-cli (setup.py)
-jinja2==2.11.3            # via sphinx
-jsonschema==3.2.0         # via okdata-sdk
-markupsafe==1.1.1         # via jinja2
-okdata-sdk==0.6.2         # via okdata-cli (setup.py)
-packaging==20.4           # via sphinx
-prettytable==0.7.2        # via okdata-cli (setup.py), okdata-sdk
-prompt-toolkit==3.0.7     # via questionary
-pyasn1==0.4.8             # via python-jose, rsa
-pygments==2.7.4           # via okdata-cli (setup.py), sphinx
-pyjwt==1.7.1              # via okdata-sdk
-pyparsing==2.4.7          # via packaging
-pyrsistent==0.16.0        # via jsonschema
-python-editor==1.0.4      # via inquirer
-python-jose==3.2.0        # via python-keycloak
-python-keycloak==0.22.0   # via okdata-sdk
-pytz==2020.1              # via babel
-questionary==1.5.2        # via okdata-cli (setup.py)
-readchar==2.0.1           # via inquirer
-recommonmark==0.6.0       # via okdata-cli (setup.py)
-requests==2.24.0          # via okdata-cli (setup.py), okdata-sdk, python-keycloak, sphinx
-rsa==4.6                  # via python-jose
-six==1.15.0               # via blessed, ecdsa, jsonschema, packaging, pyrsistent, python-jose
-snowballstemmer==2.0.0    # via sphinx
-sphinx==3.2.1             # via okdata-cli (setup.py), recommonmark
-sphinxcontrib-applehelp==1.0.2  # via sphinx
-sphinxcontrib-devhelp==1.0.2  # via sphinx
-sphinxcontrib-htmlhelp==1.0.3  # via sphinx
-sphinxcontrib-jsmath==1.0.1  # via sphinx
-sphinxcontrib-qthelp==1.0.3  # via sphinx
-sphinxcontrib-serializinghtml==1.1.4  # via sphinx
-urllib3==1.25.10          # via okdata-sdk, requests
-wcwidth==0.2.5            # via blessed, prompt-toolkit
+alabaster==0.7.12
+    # via sphinx
+attrs==20.1.0
+    # via jsonschema
+babel==2.8.0
+    # via sphinx
+blessed==1.17.6
+    # via inquirer
+certifi==2020.6.20
+    # via requests
+chardet==3.0.4
+    # via requests
+commonmark==0.9.1
+    # via recommonmark
+docopt==0.6.2
+    # via okdata-cli (setup.py)
+docutils==0.16
+    # via
+    #   recommonmark
+    #   sphinx
+ecdsa==0.14.1
+    # via python-jose
+idna==2.10
+    # via requests
+imagesize==1.2.0
+    # via sphinx
+inquirer==2.7.0
+    # via okdata-cli (setup.py)
+jinja2==2.11.3
+    # via sphinx
+jsonschema==3.2.0
+    # via okdata-sdk
+markupsafe==1.1.1
+    # via jinja2
+okdata-sdk==0.7.0
+    # via okdata-cli (setup.py)
+packaging==20.4
+    # via sphinx
+prettytable==0.7.2
+    # via
+    #   okdata-cli (setup.py)
+    #   okdata-sdk
+prompt-toolkit==3.0.7
+    # via questionary
+pyasn1==0.4.8
+    # via
+    #   python-jose
+    #   rsa
+pygments==2.7.4
+    # via
+    #   okdata-cli (setup.py)
+    #   sphinx
+pyjwt==2.0.1
+    # via okdata-sdk
+pyparsing==2.4.7
+    # via packaging
+pyrsistent==0.16.0
+    # via jsonschema
+python-editor==1.0.4
+    # via inquirer
+python-jose==3.2.0
+    # via python-keycloak
+python-keycloak==0.22.0
+    # via okdata-sdk
+pytz==2020.1
+    # via babel
+questionary==1.5.2
+    # via okdata-cli (setup.py)
+readchar==2.0.1
+    # via inquirer
+recommonmark==0.6.0
+    # via okdata-cli (setup.py)
+requests==2.24.0
+    # via
+    #   okdata-cli (setup.py)
+    #   okdata-sdk
+    #   python-keycloak
+    #   sphinx
+rsa==4.6
+    # via python-jose
+six==1.15.0
+    # via
+    #   blessed
+    #   ecdsa
+    #   jsonschema
+    #   packaging
+    #   pyrsistent
+    #   python-jose
+snowballstemmer==2.0.0
+    # via sphinx
+sphinx==3.2.1
+    # via
+    #   okdata-cli (setup.py)
+    #   recommonmark
+sphinxcontrib-applehelp==1.0.2
+    # via sphinx
+sphinxcontrib-devhelp==1.0.2
+    # via sphinx
+sphinxcontrib-htmlhelp==1.0.3
+    # via sphinx
+sphinxcontrib-jsmath==1.0.1
+    # via sphinx
+sphinxcontrib-qthelp==1.0.3
+    # via sphinx
+sphinxcontrib-serializinghtml==1.1.4
+    # via sphinx
+urllib3==1.25.10
+    # via
+    #   okdata-sdk
+    #   requests
+wcwidth==0.2.5
+    # via
+    #   blessed
+    #   prompt-toolkit
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
         "Sphinx",
         "docopt",
         "inquirer",
-        "okdata-sdk>=0.6.2",
+        "okdata-sdk>=0.6.3",
         "pygments",
         "recommonmark",
         "requests",


### PR DESCRIPTION
Raise the required okdata-sdk version to the one that supports PyJWT>=2.