### PR TITLE
DP-2079 Use the new `WebhookClient`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## ?.?.?
+
+* The new permission API based `WebhookClient` from the SDK is now used instead
+  of the deprecated `SimpleDatasetAuthorizerClient`.
+
+* [Webhook tokens](doc/webhooks.md) are now tied to an operation on a dataset
+  (read, write), instead of a specific service.
+
 ## 0.11.0
 
 * [Permissions](doc/permissions.md) can now be administered from the CLI.

--- a/doc/webhooks.md
+++ b/doc/webhooks.md
@@ -1,6 +1,7 @@
 # Webhooks
 
 To see all operations available for webhooks:
+
 ```bash
 okdata webhooks -h
 ```
@@ -9,31 +10,36 @@ Contents:
 * [What is a webhook](#what-is-a-webhook)
 * [Create token](#create-token)
 * [Delete token](#delete-token)
-
+* [List tokens](#list-tokens)
 
 ## What is a webhook
-Documentation is available on [GitHub](https://oslokommune.github.io/dataplattform/).
+
+Documentation is available on
+[our website](https://oslokommune.github.io/dataplattform/om-data/begreper).
 
 ## Create token
 
-Create a new webhook token:
+To create a new webhook token:
 
 ```bash
-okdata webhooks create-token <datasetid> <service>
+okdata webhooks create-token <datasetid> <operation>
 ```
 
-
-## List tokens
-
-Lists all active webhook tokens for a dataset:
-
-```bash
-okdata webhooks list-tokens <datasetid>
-```
+Currently supported operations are `read` and `write`, creating a token with
+read- or write access to the dataset `datasetid`, respectively.
 
 ## Delete token
-Delete (invalidate) specified webhook token:
+
+To delete (invalidate) a specified webhook token for a dataset:
 
 ```bash
 okdata webhooks delete-token <datasetid> <token>
+```
+
+## List tokens
+
+To list all active webhook tokens for a dataset:
+
+```bash
+okdata webhooks list-tokens <datasetid>
 ```

--- a/okdata/cli/commands/datasets/datasets.py
+++ b/okdata/cli/commands/datasets/datasets.py
@@ -1,9 +1,6 @@
 from okdata.sdk.data.dataset import Dataset
 from okdata.sdk.data.download import Download
 from okdata.sdk.data.upload import Upload
-from okdata.sdk.dataset_authorizer.simple_dataset_authorizer_client import (
-    SimpleDatasetAuthorizerClient,
-)
 from requests.exceptions import HTTPError
 
 from okdata.cli.command import BaseCommand, BASE_COMMAND_OPTIONS
@@ -47,7 +44,6 @@ Options:{BASE_COMMAND_OPTIONS}
         super().__init__()
         env = self.opt("env")
         self.sdk = Dataset(env=env)
-        self.simple_dataset_auth_sdk = SimpleDatasetAuthorizerClient(env=env)
         self.download = Download(env=env)
         self.handler = self.default
         self.sub_commands = [DatasetsBoilerplateCommand]

--- a/okdata/cli/commands/permissions.py
+++ b/okdata/cli/commands/permissions.py
@@ -11,8 +11,7 @@ class PermissionsCommand(BaseCommand):
     __doc__ = f"""Oslo :: Permissions
 
 Usage:
-  okdata permissions ls [--format=<format> --env=<env>]
-  okdata permissions ls <resource_name> [--format=<format> --env=<env>]
+  okdata permissions ls [<resource_name>] [--format=<format> --env=<env>]
   okdata permissions add <resource_name> <user> <scope> [--team | --client] [--env=<env>]
   okdata permissions rm <resource_name> <user> [<scope>] [--team | --client] [--env=<env>]
 

--- a/okdata/cli/commands/webhook_tokens.py
+++ b/okdata/cli/commands/webhook_tokens.py
@@ -1,23 +1,22 @@
+from okdata.sdk.webhook.client import WebhookClient
+
 from okdata.cli.command import BaseCommand, BASE_COMMAND_OPTIONS
 from okdata.cli.output import create_output
-
-from okdata.sdk.dataset_authorizer.simple_dataset_authorizer_client import (
-    SimpleDatasetAuthorizerClient,
-)
 
 
 class WebhookTokensCommand(BaseCommand):
     __doc__ = f"""Oslo :: Webhook tokens
 
 Usage:
-  okdata webhooks create-token <datasetid> <service> [options]
+  okdata webhooks create-token <datasetid> <operation> [options]
   okdata webhooks delete-token <datasetid> <token> [options]
   okdata webhooks list-tokens <datasetid> [options]
 
 Examples:
-  okdata webhooks create-token some-dataset-id some-service-name --format=json
-  okdata webhooks delete-token some-dataset-id some-webhook-token
-  okdata webhooks list-tokens some-dataset-id
+  okdata webhooks create-token my-dataset read
+  okdata webhooks create-token my-dataset write
+  okdata webhooks delete-token my-dataset 6fb92252-9390-802c-4218-ce7e1f934bf5
+  okdata webhooks list-tokens my-dataset
 
 Options:{BASE_COMMAND_OPTIONS}
     """
@@ -25,33 +24,30 @@ Options:{BASE_COMMAND_OPTIONS}
     def __init__(self):
         super().__init__()
         env = self.opt("env")
-        self.sdk = SimpleDatasetAuthorizerClient(env=env)
+        self.sdk = WebhookClient(env=env)
         self.handler = self.default
 
     def default(self):
+        dataset_id = self.arg("datasetid")
+
         if self.cmd("create-token"):
-            self.create_token()
+            self.create_token(dataset_id, self.arg("operation"))
         elif self.cmd("delete-token"):
-            self.delete_token()
+            self.delete_token(dataset_id, self.arg("token"))
         elif self.cmd("list-tokens"):
-            self.list_tokens()
+            self.list_tokens(dataset_id)
         else:
             self.print("Invalid command")
 
-    def create_token(self):
+    def create_token(self, dataset_id, operation):
         out = create_output(self.opt("format"), "webhooks_token_config.json")
         out.output_singular_object = True
-        dataset_id = self.arg("datasetid")
-        service = self.arg("service")
-        resp = self.sdk.create_webhook_token(dataset_id, service)
-        out.add_row(resp)
-        self.print("Creating webhook token", out)
+        out.add_row(self.sdk.create_webhook_token(dataset_id, operation))
+        self.print("Created webhook token:", out)
 
-    def delete_token(self):
+    def delete_token(self, dataset_id, webhook_token):
         out = create_output(self.opt("format"), "webhooks_token_delete_config.json")
         out.output_singular_object = True
-        dataset_id = self.arg("datasetid")
-        webhook_token = self.arg("token")
         resp = self.sdk.delete_webhook_token(dataset_id, webhook_token)
         data = {
             "dataset_id": dataset_id,
@@ -59,11 +55,9 @@ Options:{BASE_COMMAND_OPTIONS}
             "status": resp["message"],
         }
         out.add_row(data)
-        self.print("Deleting webhook token", out)
+        self.print("Deleted webhook token:", out)
 
-    def list_tokens(self):
+    def list_tokens(self, dataset_id):
         out = create_output(self.opt("format"), "webhook_token_list_config.json")
-        dataset_id = self.arg("datasetid")
-        webhook_tokens = self.sdk.list_webhook_tokens(dataset_id)
-        out.add_rows(webhook_tokens)
+        out.add_rows(self.sdk.list_webhook_tokens(dataset_id))
         self.print(f"Webhook tokens registered on dataset {dataset_id}: ", out)

--- a/okdata/cli/data/output-format/webhook_token_list_config.json
+++ b/okdata/cli/data/output-format/webhook_token_list_config.json
@@ -7,9 +7,9 @@
     "name": "Dataset ID",
     "key": "dataset_id"
   },
-  "Service": {
-    "name": "Service",
-    "key": "service"
+  "Operation": {
+    "name": "Operation",
+    "key": "operation"
   },
   "Expiration": {
     "name": "Expires",

--- a/okdata/cli/data/output-format/webhooks_token_config.json
+++ b/okdata/cli/data/output-format/webhooks_token_config.json
@@ -1,31 +1,30 @@
 {
-    "Token": {
-      "name": "Token",
-      "key": "token"
-    },
-    "Dataset": {
-      "name": "Dataset ID",
-      "key": "dataset_id"
-    },
-    "Service": {
-      "name": "Service",
-      "key": "service"
-    },
-    "Creation": {
-      "name": "Created",
-      "key": "created_at"
-    },
-    "Expiration": {
-      "name": "Expires",
-      "key": "expires_at"
-    },
-    "Creator": {
-      "name": "Created by",
-      "key": "created_by"
-    },
-    "Active": {
-      "name": "Active",
-      "key": "is_active"
-    }
+  "Token": {
+    "name": "Token",
+    "key": "token"
+  },
+  "Dataset": {
+    "name": "Dataset ID",
+    "key": "dataset_id"
+  },
+  "Operation": {
+    "name": "Operation",
+    "key": "operation"
+  },
+  "Creation": {
+    "name": "Created",
+    "key": "created_at"
+  },
+  "Expiration": {
+    "name": "Expires",
+    "key": "expires_at"
+  },
+  "Creator": {
+    "name": "Created by",
+    "key": "created_by"
+  },
+  "Active": {
+    "name": "Active",
+    "key": "is_active"
   }
-  
+}

--- a/requirements.txt
+++ b/requirements.txt
@@ -38,14 +38,12 @@ jsonschema==3.2.0
     # via okdata-sdk
 markupsafe==1.1.1
     # via jinja2
-okdata-sdk==0.8.1
+okdata-sdk==0.9.0
     # via okdata-cli (setup.py)
 packaging==20.4
     # via sphinx
 prettytable==0.7.2
-    # via
-    #   okdata-cli (setup.py)
-    #   okdata-sdk
+    # via okdata-cli (setup.py)
 prompt-toolkit==3.0.7
     # via questionary
 pyasn1==0.4.8

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setuptools.setup(
         "Sphinx",
         "docopt",
         "inquirer",
-        "okdata-sdk>=0.8.0",
+        "okdata-sdk>=0.9.0,<1.0.0",
         "pygments",
         "recommonmark",
         "requests",

--- a/tests/origocli/commands/webhook_tokens_test.py
+++ b/tests/origocli/commands/webhook_tokens_test.py
@@ -5,16 +5,16 @@ from conftest import set_argv
 from okdata.cli.commands.webhook_tokens import WebhookTokensCommand
 
 dataset_id = "some-dataset-id"
-service_name = "some-service-name"
 webhook_token = "27580f43-7674-4033-87e2-285db632903d"
 
 
 def test_create(mock_webhook_client, mocker):
-    set_argv("webhooks", "create-token", dataset_id, service_name)
+    operation = "write"
+    set_argv("webhooks", "create-token", dataset_id, operation)
     cmd = WebhookTokensCommand()
     mocker.spy(cmd.sdk, "create_webhook_token")
     cmd.handler()
-    cmd.sdk.create_webhook_token.assert_called_once_with(dataset_id, service_name)
+    cmd.sdk.create_webhook_token.assert_called_once_with(dataset_id, operation)
 
 
 def test_delete(mock_webhook_client, mocker):
@@ -35,7 +35,7 @@ def test_list_webhook_tokens(mock_webhook_client, mocker):
 
 @pytest.fixture()
 def mock_webhook_client(monkeypatch):
-    def create_webhook_token(self, dataset_id, version):
+    def create_webhook_token(self, dataset_id, operation):
         return {"token": webhook_token}
 
     def delete_webhook_token(self, dataset_id, token):
@@ -47,7 +47,7 @@ def mock_webhook_client(monkeypatch):
                 "token": "7271646a-8530-4ed3-a042-4485fbbd7460",
                 "created_by": "janedoe",
                 "dataset_id": "some-dataset",
-                "service": "service-account-some-service",
+                "operation": "read",
                 "created_at": "2020-07-09T06:57:36+00:00",
                 "expires_at": "2022-07-09T06:57:36+00:00",
                 "is_active": True,

--- a/tests/origocli/commands/webhook_tokens_test.py
+++ b/tests/origocli/commands/webhook_tokens_test.py
@@ -1,18 +1,15 @@
-from conftest import set_argv
 import pytest
+from okdata.sdk.webhook.client import WebhookClient
 
+from conftest import set_argv
 from okdata.cli.commands.webhook_tokens import WebhookTokensCommand
-from okdata.sdk.dataset_authorizer.simple_dataset_authorizer_client import (
-    SimpleDatasetAuthorizerClient,
-)
-
 
 dataset_id = "some-dataset-id"
 service_name = "some-service-name"
 webhook_token = "27580f43-7674-4033-87e2-285db632903d"
 
 
-def test_create(mock_simple_dataset_auth_sdk, mocker):
+def test_create(mock_webhook_client, mocker):
     set_argv("webhooks", "create-token", dataset_id, service_name)
     cmd = WebhookTokensCommand()
     mocker.spy(cmd.sdk, "create_webhook_token")
@@ -20,7 +17,7 @@ def test_create(mock_simple_dataset_auth_sdk, mocker):
     cmd.sdk.create_webhook_token.assert_called_once_with(dataset_id, service_name)
 
 
-def test_delete(mock_simple_dataset_auth_sdk, mocker):
+def test_delete(mock_webhook_client, mocker):
     set_argv("webhooks", "delete-token", dataset_id, webhook_token)
     cmd = WebhookTokensCommand()
     mocker.spy(cmd.sdk, "delete_webhook_token")
@@ -28,7 +25,7 @@ def test_delete(mock_simple_dataset_auth_sdk, mocker):
     cmd.sdk.delete_webhook_token.assert_called_once_with(dataset_id, webhook_token)
 
 
-def test_list_webhook_tokens(mock_simple_dataset_auth_sdk, mocker):
+def test_list_webhook_tokens(mock_webhook_client, mocker):
     set_argv("webhooks", "list-tokens", dataset_id)
     cmd = WebhookTokensCommand()
     mocker.spy(cmd.sdk, "list_webhook_tokens")
@@ -37,14 +34,14 @@ def test_list_webhook_tokens(mock_simple_dataset_auth_sdk, mocker):
 
 
 @pytest.fixture()
-def mock_simple_dataset_auth_sdk(monkeypatch):
-    def create_webhook_token_return(self, dataset_id, version):
+def mock_webhook_client(monkeypatch):
+    def create_webhook_token(self, dataset_id, version):
         return {"token": webhook_token}
 
-    def delete_webhook_token_return(self, dataset_id, token):
+    def delete_webhook_token(self, dataset_id, token):
         return {"message": "Deleted"}
 
-    def list_webhook_tokens_return(self, dataset_id):
+    def list_webhook_tokens(self, dataset_id):
         return [
             {
                 "token": "7271646a-8530-4ed3-a042-4485fbbd7460",
@@ -57,20 +54,6 @@ def mock_simple_dataset_auth_sdk(monkeypatch):
             }
         ]
 
-    monkeypatch.setattr(
-        SimpleDatasetAuthorizerClient,
-        "create_webhook_token",
-        create_webhook_token_return,
-    )
-
-    monkeypatch.setattr(
-        SimpleDatasetAuthorizerClient,
-        "delete_webhook_token",
-        delete_webhook_token_return,
-    )
-
-    monkeypatch.setattr(
-        SimpleDatasetAuthorizerClient,
-        "list_webhook_tokens",
-        list_webhook_tokens_return,
-    )
+    monkeypatch.setattr(WebhookClient, "create_webhook_token", create_webhook_token)
+    monkeypatch.setattr(WebhookClient, "delete_webhook_token", delete_webhook_token)
+    monkeypatch.setattr(WebhookClient, "list_webhook_tokens", list_webhook_tokens)


### PR DESCRIPTION
Use the new permission API based `WebhookClient` from the SDK instead of the deprecated `SimpleDatasetAuthorizerClient`.

Webhook tokens are now tied to an operation on a dataset (read, write), instead of a specific service.