### PR TITLE
DP-2288 Add rogue command `pubreg list-keys`

### DIFF
--- a/okdata/cli/__main__.py
+++ b/okdata/cli/__main__.py
@@ -11,6 +11,7 @@ from okdata.cli.commands.datasets import DatasetsCommand
 from okdata.cli.commands.events import EventsCommand
 from okdata.cli.commands.permissions import PermissionsCommand
 from okdata.cli.commands.pipelines import Pipelines
+from okdata.cli.commands.pubreg import PubregCommand
 from okdata.cli.commands.status import StatusCommand
 from okdata.cli.commands.webhook_tokens import WebhookTokensCommand
 
@@ -58,15 +59,14 @@ def main():
 def get_command_class(argv):
     commands = {
         "datasets": DatasetsCommand,
-        "pipelines": Pipelines,
         "events": EventsCommand,
-        "status": StatusCommand,
         "permissions": PermissionsCommand,
+        "pipelines": Pipelines,
+        "pubreg": PubregCommand,
+        "status": StatusCommand,
         "webhooks": WebhookTokensCommand,
     }
-    if argv[1] in commands:
-        return commands[argv[1]]
-    return False
+    return commands.get(argv[1], False)
 
 
 if __name__ == "__main__":

--- a/okdata/cli/commands/pubreg/__init__.py
+++ b/okdata/cli/commands/pubreg/__init__.py
@@ -1,0 +1,3 @@
+from okdata.cli.commands.pubreg.pubreg import PubregCommand
+
+__all__ = ["PubregCommand"]

--- a/okdata/cli/commands/pubreg/client.py
+++ b/okdata/cli/commands/pubreg/client.py
@@ -1,0 +1,19 @@
+import logging
+
+from okdata.sdk import SDK
+
+log = logging.getLogger()
+
+
+class PubregClient(SDK):
+    def __init__(self, config=None, auth=None, env=None):
+        self.__name__ = "pubreg"
+        super().__init__(config, auth, env)
+        self.api_url = "https://api.data{}.oslo.systems/maskinporten".format(
+            "-dev" if self.config.config["env"] == "dev" else ""
+        )
+
+    def get_keys(self, env, client_id):
+        url = f"{self.api_url}/clients/{env}/{client_id}/keys"
+        log.info(f"Listing keys from: {url}")
+        return self.get(url).json()

--- a/okdata/cli/commands/pubreg/pubreg.py
+++ b/okdata/cli/commands/pubreg/pubreg.py
@@ -1,0 +1,32 @@
+from operator import itemgetter
+
+from okdata.cli.command import BASE_COMMAND_OPTIONS, BaseCommand
+from okdata.cli.commands.pubreg.client import PubregClient
+from okdata.cli.output import create_output
+
+
+class PubregCommand(BaseCommand):
+    __doc__ = f"""Oslo :: Public registers
+
+Usage:
+  okdata pubreg list-keys <maskinporten-env> <client-id> [--env=<env>]
+
+Examples:
+  okdata pubreg list-keys test my-client
+
+Options:{BASE_COMMAND_OPTIONS}
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.client = PubregClient(env=self.opt("env"))
+
+    def handler(self):
+        if self.cmd("list-keys"):
+            self.list_client_keys(self.arg("maskinporten-env"), self.arg("client-id"))
+
+    def list_client_keys(self, env, client_id):
+        keys = self.client.get_keys(env, client_id)
+        out = create_output(self.opt("format"), "pubreg_client_keys_config.json")
+        out.add_rows(sorted(keys, key=itemgetter("kid")))
+        self.print(f"Keys for client {client_id} ({env}):", out)

--- a/okdata/cli/data/output-format/pubreg_client_keys_config.json
+++ b/okdata/cli/data/output-format/pubreg_client_keys_config.json
@@ -1,0 +1,6 @@
+{
+  "Key ID": {
+    "name": "Key ID",
+    "key": "kid"
+  }
+}


### PR DESCRIPTION
Add an initial public register command for listing the keys of a Maskinporten client. The command is currently going rogue and staying undocumented, since it's only intended for internal use for the time being.