### PR TITLE
T#160 Avoid overwriting attributes in sub-classes

### DIFF
--- a/okdata/cli/command.py
+++ b/okdata/cli/command.py
@@ -49,13 +49,12 @@ Options:{BASE_COMMAND_OPTIONS}
     args: dict
     handler: ()
 
-    def __init__(self, sdk=None):
+    def __init__(self, sdk=SDK):
         self.args = docopt(str(self.__doc__))
-        self.sdk = sdk
+        self.sdk = sdk(env=self.opt("env"))
+
         if self.opt("debug"):
             logging.basicConfig(level=logging.DEBUG)
-        if self.sdk is None:
-            self.sdk = SDK(env=self.opt("env"))
 
     def handle(self):
         self.args = docopt(str(self.__doc__))
@@ -63,7 +62,7 @@ Options:{BASE_COMMAND_OPTIONS}
             for cmd in self.sub_commands:
                 try:
                     self.log.debug(f"Checking if sub_command '{cmd.__name__}' is valid")
-                    return cmd(self.sdk).handle()
+                    return cmd(self.sdk.__class__).handle()
                 except DocoptExit as d:
                     self.log.debug(d.usage)
                     continue

--- a/okdata/cli/commands/datasets/datasets.py
+++ b/okdata/cli/commands/datasets/datasets.py
@@ -41,10 +41,8 @@ Options:{BASE_COMMAND_OPTIONS}
     """
 
     def __init__(self):
-        super().__init__()
-        env = self.opt("env")
-        self.sdk = Dataset(env=env)
-        self.download = Download(env=env)
+        super().__init__(Dataset)
+        self.download = Download(env=self.opt("env"))
         self.handler = self.default
         self.sub_commands = [DatasetsBoilerplateCommand]
 

--- a/okdata/cli/commands/events.py
+++ b/okdata/cli/commands/events.py
@@ -43,13 +43,10 @@ Options:{BASE_COMMAND_OPTIONS}
     """
 
     def __init__(self):
-        super().__init__()
+        super().__init__(EventStreamClient)
         env = self.opt("env")
-
-        self.sdk = EventStreamClient(env=env)
         self.post_event_sdk = PostEvent(env=env)
         self.esq_sdk = ElasticsearchQueries(env=env)
-
         self.handler = self.default
 
     def default(self):

--- a/okdata/cli/commands/pipelines/pipelines.py
+++ b/okdata/cli/commands/pipelines/pipelines.py
@@ -70,7 +70,7 @@ class Pipelines(BaseCommand):
     """
 
     def __init__(self):
-        super().__init__(PipelineApiClient())
+        super().__init__(PipelineApiClient)
         self.sdk.login()
         self.handler = self.default
         self.sub_commands = [

--- a/okdata/cli/commands/status.py
+++ b/okdata/cli/commands/status.py
@@ -20,9 +20,7 @@ Options:{BASE_COMMAND_OPTIONS}
     """
 
     def __init__(self):
-        super().__init__()
-        env = self.opt("env")
-        self.sdk = Status(env=env)
+        super().__init__(Status)
         self.handler = self.default
 
     def login(self):

--- a/okdata/cli/commands/webhook_tokens.py
+++ b/okdata/cli/commands/webhook_tokens.py
@@ -22,9 +22,7 @@ Options:{BASE_COMMAND_OPTIONS}
     """
 
     def __init__(self):
-        super().__init__()
-        env = self.opt("env")
-        self.sdk = WebhookClient(env=env)
+        super().__init__(WebhookClient)
         self.handler = self.default
 
     def default(self):

--- a/tests/origocli/commands/pipeline_test.py
+++ b/tests/origocli/commands/pipeline_test.py
@@ -21,7 +21,7 @@ from okdata.cli.commands.pipelines.schemas import SchemasLs, SchemasCreate
 pipeline_qual = f"{Pipeline.__module__}.{Pipeline.__name__}"
 pipeline_client_qual = f"{PipelineApiClient.__module__}.{PipelineApiClient.__name__}"
 
-sdk = PipelineApiClient()
+sdk = PipelineApiClient
 
 
 def _HTTPError400():
@@ -83,7 +83,6 @@ class TestCreate:
     def test_handler_with_create_error(self, mocker):
         set_argv("pipelines", "create", "something.json", "--format=json")
 
-        sdk = PipelineApiClient()
         mocker.patch(
             "builtins.open",
             mocker.mock_open(
@@ -110,7 +109,7 @@ class TestPipelinesLs:
         set_argv("pipelines", "ls")
         list = mocker.patch(f"{pipeline_client_qual}.list")
         print = mocker.patch(f"{BASECMD_QUAL}.print")
-        PipelinesLs(PipelineApiClient()).handler()
+        PipelinesLs(sdk).handler()
         assert list.called
         assert print.called
 


### PR DESCRIPTION
Avoid overwriting the `sdk` attribute in sub-classes of `BaseCommand` as suggested by CodeQL. Make some additional cleanups along the way while we're at it.