### PR TITLE
T#169 Tweak Maskinporten client name pattern

### DIFF
--- a/okdata/cli/commands/pubreg/pubreg.py
+++ b/okdata/cli/commands/pubreg/pubreg.py
@@ -1,4 +1,3 @@
-import uuid
 from operator import itemgetter
 
 from requests.exceptions import HTTPError
@@ -51,10 +50,11 @@ Options:{BASE_COMMAND_OPTIONS}
 
         team = config["team"]
         provider = config["provider"]
+        integration = config["integration"]
         env = config["environment"]
         scopes = config["scopes"]
 
-        name = f"{team}-{provider}-{env}-{uuid.uuid4()}"
+        name = f"{team}-{provider}-{integration}"
 
         self.confirm_to_continue(
             f"Will create a new client '{name}' in {env} with scopes {scopes}."

--- a/okdata/cli/commands/pubreg/wizards.py
+++ b/okdata/cli/commands/pubreg/wizards.py
@@ -1,3 +1,5 @@
+import re
+
 from prompt_toolkit.styles import Style
 from questionary import Choice, prompt
 
@@ -74,6 +76,17 @@ class ClientCreateWizard:
                     "choices": [Choice(*p) for p in _providers],
                 },
                 {
+                    "type": "text",
+                    "qmark": "*",
+                    "style": required_style,
+                    "name": "integration",
+                    "message": "Component/integration name",
+                    "validate": (
+                        lambda text: bool(re.fullmatch("[0-9a-z-]+", text))
+                        or 'Only lowercase letters, numbers and "-", please'
+                    ),
+                },
+                {
                     "type": "checkbox",
                     "qmark": "*",
                     "style": required_style,
@@ -97,6 +110,7 @@ class ClientCreateWizard:
 
         return {
             "provider": choices["provider"],
+            "integration": choices["integration"],
             "scopes": choices["scopes"],
             "environment": choices["environment"],
             "team": choices.get("team"),

--- a/okdata/cli/commands/pubreg/wizards.py
+++ b/okdata/cli/commands/pubreg/wizards.py
@@ -56,6 +56,13 @@ _scopes = {
 class ClientCreateWizard:
     """Wizard for the `pubreg create-client` command."""
 
+    def _validate_integration(self, text):
+        if len(text) > 30:
+            return "Too long!"
+        if not re.fullmatch("[0-9a-z-]+", text):
+            return 'Only lowercase letters, numbers and "-", please'
+        return True
+
     def start(self):
         choices = prompt(
             [
@@ -81,10 +88,7 @@ class ClientCreateWizard:
                     "style": required_style,
                     "name": "integration",
                     "message": "Component/integration name",
-                    "validate": (
-                        lambda text: bool(re.fullmatch("[0-9a-z-]+", text))
-                        or 'Only lowercase letters, numbers and "-", please'
-                    ),
+                    "validate": self._validate_integration,
                 },
                 {
                     "type": "checkbox",


### PR DESCRIPTION
Change the generated Maskinporten client name from `<team>-<provider>-<env>-<uuid>` to `<team>-<provider>-<integration>`, which is closer to the pattern used for existing clients.