### PR TITLE
T#167 Handle more general request errors

### DIFF
--- a/okdata/cli/__main__.py
+++ b/okdata/cli/__main__.py
@@ -1,10 +1,9 @@
 import json
 import sys
 
-from requests.exceptions import HTTPError
 from keycloak.exceptions import KeycloakGetError
-
 from okdata.sdk.exceptions import ApiAuthenticateError
+from requests.exceptions import RequestException
 
 from okdata.cli.command import BaseCommand
 from okdata.cli.commands.datasets import DatasetsCommand
@@ -29,25 +28,34 @@ def main():
         try:
             instance.login()
             instance.handle()
-        except HTTPError as he:
-            instance.print_error_response(he.response.json())
+        except RequestException as e:
+            if hasattr(e.response, "json"):
+                instance.print_error_response(e.response.json())
+            else:
+                instance.print(
+                    "A server error occurred. Please try again, or contact "
+                    "Datapatruljen if the problem persists.",
+                )
         except ApiAuthenticateError:
             instance.print(
-                "An error occured (ApiAuthenticateError): Invalid credentials",
+                "An error occurred (ApiAuthenticateError): Invalid credentials",
                 {"error": 1, "message": "Invalid credentials"},
             )
         except KeycloakGetError as e:
             error = json.loads(e.error_message)
             instance.log.info(f"Keycloak reported: {e}")
             instance.print(
-                f"An error occured (KeycloakGetError): {error['error_description']}"
+                f"An error occurred (KeycloakGetError): {error['error_description']}"
             )
         except Exception as e:
             instance.print(
-                "A Exception occured",
+                "An exception occurred",
                 {
                     "error": 1,
-                    "message": "okdata-cli failed with exception, see log output for more information",
+                    "message": (
+                        "okdata-cli failed with an exception, see log output "
+                        "for more information",
+                    ),
                 },
             )
             instance.log.exception(f"okdata-cli failed with: {e}")

--- a/okdata/cli/command.py
+++ b/okdata/cli/command.py
@@ -153,7 +153,7 @@ Options:{BASE_COMMAND_OPTIONS}
 
 
 def generate_error_feedback(message, errors=None):
-    feedback = f"An error occured: {message}"
+    feedback = f"An error occurred: {message}"
     if errors:
         feedback += f"\nCause:\n\t{errors}"
 

--- a/okdata/cli/data/boilerplate/bin/run.sh
+++ b/okdata/cli/data/boilerplate/bin/run.sh
@@ -36,7 +36,7 @@ dataset_data=`cat $dataset_file`
 if [[ $dataset_data =~ "boilerplate" || $dataset_data =~ "my.address@example.org" || $dataset_data =~ "Publisher Name" ]]
 then
    echo "Error: $dataset_file has not been updated correctly - please change the data to represent the dataset you want to create and the organization creating it!"
-   echo "Note: Change all occurence of 'boilerplate', contact and publisher must be a real contact point"
+   echo "Note: Change all occurrences of 'boilerplate', contact and publisher must be a real contact point"
    exit
 fi
 

--- a/tests/origocli/cli_test.py
+++ b/tests/origocli/cli_test.py
@@ -41,7 +41,7 @@ def test_main_auth_error(auth_failed, capsys):
     sys.argv = ["okdata", "datasets", "create"]
     main()
     captured = capsys.readouterr().out.strip("\n")
-    assert "An error occured (ApiAuthenticateError)" in captured
+    assert "An error occurred (ApiAuthenticateError)" in captured
 
 
 @pytest.fixture()

--- a/tests/origocli/commands/datasets/boilerplate/validator_test.py
+++ b/tests/origocli/commands/datasets/boilerplate/validator_test.py
@@ -14,7 +14,7 @@ from okdata.cli.commands.datasets.boilerplate.validator import (
 )
 
 # Note: no testing of return values since the validator is only
-# interested in ValidationError occurences
+# interested in ValidationError occurrences
 
 
 class TestDateValidator:


### PR DESCRIPTION
Handle more general exceptions from the `requests` library, such as connection errors and retry errors.