### PR TITLE
T#180 Tweak client creation payload

### DIFF
--- a/okdata/cli/commands/pubreg/client.py
+++ b/okdata/cli/commands/pubreg/client.py
@@ -13,8 +13,14 @@ class PubregClient(SDK):
             "-dev" if self.config.config["env"] == "dev" else ""
         )
 
-    def create_client(self, env, name, scopes):
-        data = {"env": env, "name": name, "description": name, "scopes": scopes}
+    def create_client(self, team_id, provider, integration, scopes, env):
+        data = {
+            "team_id": team_id,
+            "provider": provider,
+            "integration": integration,
+            "scopes": scopes,
+            "env": env,
+        }
         log.info(f"Creating client with payload: {data}")
         return self.post(f"{self.api_url}/clients", data=data).json()
 

--- a/okdata/cli/commands/pubreg/pubreg.py
+++ b/okdata/cli/commands/pubreg/pubreg.py
@@ -59,21 +59,21 @@ Options:{BASE_COMMAND_OPTIONS}
     def create_client(self):
         config = CreateClientWizard().start()
 
-        env = config["env"]
-        team = config["team"]
+        team_id = config["team_id"]
         provider = config["provider"]
         integration = config["integration"]
         scopes = config["scopes"]
-
-        name = f"{team}-{provider}-{integration}"
+        env = config["env"]
 
         self.confirm_to_continue(
-            f"Will create a new client '{name}' in {env} with scopes {scopes}."
+            f"Will create a new client for {provider} in {env} with scopes {scopes}."
         )
 
         try:
-            self.print(f"Creating '{name}'...")
-            response = self.client.create_client(env, name, scopes)
+            self.print("Creating client...")
+            response = self.client.create_client(
+                team_id, provider, integration, scopes, env
+            )
             client_id = response["client_id"]
             self.print(f"Done! Created a new client with ID '{client_id}'.")
         except HTTPError as e:

--- a/okdata/cli/commands/pubreg/wizards.py
+++ b/okdata/cli/commands/pubreg/wizards.py
@@ -5,19 +5,6 @@ from questionary import Choice, prompt
 
 required_style = Style([("qmark", "fg:red bold")])
 
-_teams = [
-    ("Barnehagepris", "barnehagepris"),
-    ("Booking", "booking"),
-    ("Datapatruljen", "datapatruljen"),
-    ("Dataspeilet", "dataspeilet"),
-    ("Informasjonsflyt", "informasjonsflyt"),
-    ("Kjøremiljø og verktøy", "kjoremiljo"),
-    ("Legevaktmottak", "legevaktmottak"),
-    ("Min Side", "min-side"),
-    ("Oslonøkkelen", "oslonokkelen"),
-    ("Skjema", "skjema"),
-    ("Veiviser", "veiviser"),
-]
 
 _providers = [
     ("Folkeregisteret", "freg"),
@@ -70,6 +57,24 @@ class NoClientsError(Exception):
 class CreateClientWizard:
     """Wizard for the `pubreg create-client` command."""
 
+    def _team_choices(self, env):
+        # TODO: Fetch the team list from permission-api with the real Keycloak
+        #       group IDs once permission-api supports it (T#179).
+        teams = [
+            {"name": "Barnehagepris", "id": "barnehagepris"},
+            {"name": "Booking", "id": "booking"},
+            {"name": "Datapatruljen", "id": "datapatruljen"},
+            {"name": "Dataspeilet", "id": "dataspeilet"},
+            {"name": "Informasjonsflyt", "id": "informasjonsflyt"},
+            {"name": "Kjøremiljø og verktøy", "id": "kjoremiljo"},
+            {"name": "Legevaktmottak", "id": "legevaktmottak"},
+            {"name": "Min Side", "id": "min-side"},
+            {"name": "Oslonøkkelen", "id": "oslonokkelen"},
+            {"name": "Skjema", "id": "skjema"},
+            {"name": "Veiviser", "id": "veiviser"},
+        ]
+        return [Choice(t["name"], t["id"]) for t in teams]
+
     def _validate_integration(self, text):
         if len(text) > 30:
             return "Too long!"
@@ -92,9 +97,9 @@ class CreateClientWizard:
                     "type": "select",
                     "qmark": "*",
                     "style": required_style,
-                    "name": "team",
+                    "name": "team_id",
                     "message": "Team",
-                    "choices": [Choice(*t) for t in _teams],
+                    "choices": lambda x: self._team_choices(x["env"]),
                 },
                 {
                     "type": "select",
@@ -128,7 +133,7 @@ class CreateClientWizard:
 
         return {
             "env": choices["env"],
-            "team": choices.get("team"),
+            "team_id": choices.get("team_id"),
             "provider": choices["provider"],
             "integration": choices["integration"],
             "scopes": choices["scopes"],


### PR DESCRIPTION
Send team ID, provider and integration to the Maskinporten API so the client name can be constructed there, instead of making it in the CLI.

Real team IDs will later be fetched from Keycloak.