### PR TITLE
Key deletion doesn't affect SSM anymore

### DIFF
--- a/okdata/cli/commands/pubreg/client.py
+++ b/okdata/cli/commands/pubreg/client.py
@@ -37,7 +37,7 @@ class PubregClient(SDK):
     def delete_key(self, env, client_id, key_id):
         url = f"{self.api_url}/clients/{env}/{client_id}/keys/{key_id}"
         log.info(f"Deleting key: {url}")
-        return self.delete(url).json()
+        return self.delete(url)
 
     def get_keys(self, env, client_id):
         url = f"{self.api_url}/clients/{env}/{client_id}/keys"

--- a/okdata/cli/commands/pubreg/pubreg.py
+++ b/okdata/cli/commands/pubreg/pubreg.py
@@ -188,14 +188,8 @@ Options:{BASE_COMMAND_OPTIONS}
             self.print(
                 f"Deleting key '{key_id}' from '{client_id}' ({env})...",
             )
-            res = self.client.delete_key(env, client_id, key_id)
-            self.print(
-                "Done! The key is deleted and will no longer work, {}.".format(
-                    "and has been removed from SSM"
-                    if res["deleted_from_ssm"]
-                    else "but it has not been removed from SSM"
-                )
-            )
+            self.client.delete_key(env, client_id, key_id)
+            self.print("Done! The key is deleted and will no longer work.")
         except HTTPError as e:
             message = e.response.json()["message"]
             self.print(f"Something went wrong: {message}")


### PR DESCRIPTION
Deleting keys doesn't cause changes in SSM anymore. The key parameters will be cleaned out when the client itself is deleted instead.