### PR TITLE
T#274 Add `pubreg audit-log` command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## ?.?.?
+
+* A new command `pubreg audit-log` for viewing audit logs of Maskinporten
+  clients has been added.
+
 ## 1.2.0
 
 * The `pubreg delete-client` command now offers to delete the SSM key parameters

--- a/doc/pubreg.md
+++ b/doc/pubreg.md
@@ -130,3 +130,6 @@ okdata pubreg audit-log
 Audit logs contain the history of events related to clients, including their
 creation time, when keys are added and deleted, and the username of the user who
 performed each action.
+
+Note that audit logs for deleted clients can't be retrieved this way. Should
+that become necessary, please contact Dataspeilet.

--- a/doc/pubreg.md
+++ b/doc/pubreg.md
@@ -17,6 +17,7 @@ Contents:
 * [Rotating a client key](#rotating-a-client-key)
 * [Listing client keys](#listing-client-keys)
 * [Deleting a client key](#deleting-a-client-key)
+* [Viewing a client's audit log](#viewing-a-clients-audit-log)
 
 ## Prerequisites
 
@@ -117,3 +118,15 @@ Note that key deletion is irreversible.
 Also note that due to how Maskinporten works, the expiration date of every
 existing key will be updated to today's date when creating a new key. Digdir is
 looking into a fix for this issue.
+
+## Viewing a client's audit log
+
+To view the audit log for a client, use the following command:
+
+```sh
+okdata pubreg audit-log
+```
+
+Audit logs contain the history of events related to clients, including their
+creation time, when keys are added and deleted, and the username of the user who
+performed each action.

--- a/okdata/cli/commands/pubreg/client.py
+++ b/okdata/cli/commands/pubreg/client.py
@@ -60,3 +60,8 @@ class PubregClient(SDK):
         url = f"{self.api_url}/clients/{env}/{client_id}/keys"
         log.info(f"Listing keys from: {url}")
         return self.get(url).json()
+
+    def get_audit_log(self, env, client_id):
+        url = f"{self.api_url}/audit/{env}/{client_id}/log"
+        log.info(f"Fetching audit log from: {url}")
+        return self.get(url).json()

--- a/okdata/cli/commands/pubreg/wizards.py
+++ b/okdata/cli/commands/pubreg/wizards.py
@@ -108,3 +108,12 @@ def delete_key_wizard(pubreg_client):
         "client_name": choices["client"]["name"],
         "key_id": choices["key_id"],
     }
+
+
+def audit_log_wizard(pubreg_client):
+    choices = _run_questionnaire(q_env(), q_client(pubreg_client))
+    return {
+        "env": choices["env"],
+        "client_id": choices["client"]["id"],
+        "client_name": choices["client"]["name"],
+    }

--- a/okdata/cli/data/output-format/pubreg_audit_log_config.json
+++ b/okdata/cli/data/output-format/pubreg_audit_log_config.json
@@ -1,0 +1,22 @@
+{
+  "Time": {
+    "name": "Time",
+    "key": "timestamp"
+  },
+  "Action": {
+    "name": "Action",
+    "key": "action"
+  },
+  "User": {
+    "name": "User",
+    "key": "user"
+  },
+  "Scopes": {
+    "name": "Scopes",
+    "key": "scopes"
+  },
+  "Key ID": {
+    "name": "Key ID",
+    "key": "key_id"
+  }
+}

--- a/okdata/cli/output.py
+++ b/okdata/cli/output.py
@@ -74,14 +74,13 @@ class TableOutput(PrettyTable):
         return value
 
     def get_row_value(self, row, key):
-        value = "N/A"
         row_key = self.config[key]["key"]
         if row_key in row:
             if "fields" in self.config[key]:
-                value = self.field_values(row, row_key, key)
-            else:
-                value = row[row_key]
-        return value
+                return self.field_values(row, row_key, key)
+            if row[row_key] is not None:
+                return row[row_key]
+        return "N/A"
 
     def add_row(self, row):
         row_data = []


### PR DESCRIPTION
Add a new `pubreg audit-log` command for viewing the audit logs of Maskinporten clients.

Depends on https://github.com/oslokommune/okdata-maskinporten-api/pull/98.