### PR TITLE
T#294 Start a new "teams" family of commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,8 +2,9 @@
 
 * A new command `pubreg audit-log` for viewing audit logs of Maskinporten
   clients has been added.
-
 * Automatic client key rotation is now offered when creating a new client key.
+* A new family of `team` commands and been added for viewing and (later) editing
+  teams.
 
 ## 1.2.0
 

--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@ Okdata CLI provides a unified interface to data services for Oslo Origo teams.
 * [Install](doc/install.md)
 * [Configuration](doc/configuration.md)
 * [Datasets](doc/datasets.md)
-* [Pipelines](doc/pipelines.md)
 * [Permissions](doc/permissions.md)
+* [Pipelines](doc/pipelines.md)
 * [Public registers](doc/pubreg.md)
+* [Teams](doc/teams.md)

--- a/doc/teams.md
+++ b/doc/teams.md
@@ -1,0 +1,27 @@
+# Teams
+
+Commands related to management of teams are grouped under the `teams` command
+prefix. Run the following command to see a list of all available `teams`
+commands:
+
+```sh
+okdata teams -h
+```
+
+Contents:
+* [Listing teams](#listing-teams)
+
+## Listing teams
+
+The following command displays a list of every Origo team along with your
+membership status in each of them:
+
+```sh
+okdata teams ls
+```
+
+Use the `--my` option to list only those teams you're a member of:
+
+```sh
+okdata teams ls --my
+```

--- a/okdata/cli/__main__.py
+++ b/okdata/cli/__main__.py
@@ -11,6 +11,7 @@ from okdata.cli.commands.permissions import PermissionsCommand
 from okdata.cli.commands.pipelines import Pipelines
 from okdata.cli.commands.pubreg import PubregCommand
 from okdata.cli.commands.status import StatusCommand
+from okdata.cli.commands.teams import TeamsCommand
 
 
 def main():
@@ -71,6 +72,7 @@ def get_command_class(argv):
         "pipelines": Pipelines,
         "pubreg": PubregCommand,
         "status": StatusCommand,
+        "teams": TeamsCommand,
     }
     return commands.get(argv[1], False)
 

--- a/okdata/cli/command.py
+++ b/okdata/cli/command.py
@@ -24,18 +24,20 @@ class BaseCommand:
 
 usage:
   okdata datasets [options]
-  okdata status [options]
-  okdata pipelines [options]
   okdata permissions [options]
+  okdata pipelines [options]
   okdata pubreg [options]
+  okdata status [options]
+  okdata teams [options]
   okdata -h | --help
 
 Commands available:
   datasets
-  status
-  pipelines
   permissions
+  pipelines
   pubreg
+  status
+  teams
 
 Options:{BASE_COMMAND_OPTIONS}
 """

--- a/okdata/cli/commands/teams.py
+++ b/okdata/cli/commands/teams.py
@@ -1,0 +1,36 @@
+from operator import itemgetter
+
+from okdata.sdk.team.client import TeamClient
+
+from okdata.cli.command import BASE_COMMAND_OPTIONS, BaseCommand
+from okdata.cli.output import create_output
+
+
+class TeamsCommand(BaseCommand):
+    __doc__ = f"""Oslo :: Teams
+
+Usage:
+  okdata teams ls [--my] [options]
+
+Examples:
+  okdata teams ls
+  okdata teams ls --my
+
+Options:{BASE_COMMAND_OPTIONS}
+    """
+
+    def __init__(self):
+        super().__init__()
+        self.client = TeamClient(env=self.opt("env"))
+
+    def handler(self):
+        if self.cmd("ls"):
+            self.ls(self.opt("my"))
+
+    def ls(self, my):
+        teams = self.client.get_teams(
+            include=None if my else "all", has_role="origo-team"
+        )
+        out = create_output(self.opt("format"), "teams_config.json")
+        out.add_rows(sorted(teams, key=itemgetter("name")))
+        self.print("{} teams:".format("My" if my else "All"), out)

--- a/okdata/cli/data/output-format/teams_config.json
+++ b/okdata/cli/data/output-format/teams_config.json
@@ -1,0 +1,10 @@
+{
+  "Name": {
+    "name": "Name",
+    "key": "name"
+  },
+  "Member?": {
+    "name": "Member?",
+    "key": "is_member"
+  }
+}

--- a/okdata/cli/output.py
+++ b/okdata/cli/output.py
@@ -123,6 +123,8 @@ class TableOutput(PrettyTable):
                 ]
             value = ["- " + v for v in value]
             value = "  \n".join(value)
+        elif isinstance(value, bool):
+            value = "Yes" if value else "No"
         elif max_width and len(value) > max_width:
             value = fill(value, width=max_width)
         return value

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ idna==3.3
     # via requests
 jsonschema==4.4.0
     # via okdata-sdk
-okdata-sdk==2.0.0
+okdata-sdk==2.2.0
     # via okdata-cli (setup.py)
 prettytable==3.2.0
     # via okdata-cli (setup.py)

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setuptools.setup(
     install_requires=[
         "PrettyTable",
         "docopt",
-        "okdata-sdk>=2.0.0,<3.0.0",
+        "okdata-sdk>=2.2.0,<3.0.0",
         "pygments>=2.11.2,<3.0.0",
         "questionary>=1.10.0,<2.0.0",
         "requests",


### PR DESCRIPTION
Also add the initial member of the family: `teams ls`.

Depends on https://github.com/oslokommune/okdata-sdk-python/pull/101 being released as 2.2.0 and this PR being updated (`setup.py` + `requirements.txt`) to reflect this.