### PR TITLE
T#298 Add `teams list-members` command

### DIFF
--- a/doc/teams.md
+++ b/doc/teams.md
@@ -11,6 +11,7 @@ okdata teams -h
 Contents:
 * [Listing teams](#listing-teams)
 * [Editing team details](#editing-team-details)
+* [Listing team members](#listing-team-members)
 
 ## Listing teams
 
@@ -40,3 +41,19 @@ The attributes you can edit are the team's:
 - Name
 - Email address
 - Slack channel URL
+
+## Listing team members
+
+The following command lets you pick a team and list its members (even from the
+ones you're not a member of):
+
+```sh
+okdata teams list-members
+```
+
+Use the `--my` option to restrict the selection of teams to those you're a
+member of:
+
+```sh
+okdata teams list-members --my
+```

--- a/okdata/cli/commands/teams/questions.py
+++ b/okdata/cli/commands/teams/questions.py
@@ -9,9 +9,11 @@ class NoTeamError(Exception):
     pass
 
 
-def q_team(team_client):
+def q_team(team_client, my=True):
     def _team_choices():
-        teams = team_client.get_teams(has_role="origo-team")
+        teams = team_client.get_teams(
+            include=None if my else "all", has_role="origo-team"
+        )
 
         if not teams:
             raise NoTeamError

--- a/okdata/cli/commands/teams/teams.py
+++ b/okdata/cli/commands/teams/teams.py
@@ -104,5 +104,12 @@ Options:{BASE_COMMAND_OPTIONS}
             return
 
         out = create_output(self.opt("format"), "team_members_config.json")
-        out.add_rows(sorted(members, key=itemgetter("name")))
+
+        # Sort by name and username. Users without name are sorted last.
+        out.add_rows(
+            sorted(
+                members,
+                key=lambda u: (not u["name"], u["name"] or "", u["username"]),
+            ),
+        )
         self.print("Team members", out)

--- a/okdata/cli/commands/teams/teams.py
+++ b/okdata/cli/commands/teams/teams.py
@@ -5,7 +5,7 @@ from requests.exceptions import HTTPError
 
 from okdata.cli.command import BASE_COMMAND_OPTIONS, BaseCommand
 from okdata.cli.commands.teams.questions import NoTeamError
-from okdata.cli.commands.teams.wizards import edit_team_wizard
+from okdata.cli.commands.teams.wizards import edit_team_wizard, list_members_wizard
 from okdata.cli.output import create_output
 
 
@@ -15,11 +15,13 @@ class TeamsCommand(BaseCommand):
 Usage:
   okdata teams ls [--my] [options]
   okdata teams edit [options]
+  okdata teams list-members [--my] [options]
 
 Examples:
   okdata teams ls
   okdata teams ls --my
   okdata teams edit
+  okdata teams list-members --my
 
 Options:{BASE_COMMAND_OPTIONS}
     """
@@ -33,6 +35,8 @@ Options:{BASE_COMMAND_OPTIONS}
             self.ls(self.opt("my"))
         if self.cmd("edit"):
             self.edit()
+        if self.cmd("list-members"):
+            self.list_members(self.opt("my"))
 
     def ls(self, my):
         try:
@@ -81,3 +85,24 @@ Options:{BASE_COMMAND_OPTIONS}
                 message = data["message"]
 
             self.print(f"Something went wrong: {message}")
+
+    def list_members(self, my):
+        try:
+            config = list_members_wizard(self.client, my)
+            members = self.client.get_team_members(config["team_id"])
+        except NoTeamError:
+            self.print(
+                "We haven't yet registered you as member of any Origo team. "
+                "Please contact Datapatruljen to get it done."
+                if my
+                else "No teams exist yet."
+            )
+            return
+        except HTTPError as e:
+            message = e.response.json()["message"]
+            self.print(f"Something went wrong: {message}")
+            return
+
+        out = create_output(self.opt("format"), "team_members_config.json")
+        out.add_rows(sorted(members, key=itemgetter("name")))
+        self.print("Team members", out)

--- a/okdata/cli/commands/teams/wizards.py
+++ b/okdata/cli/commands/teams/wizards.py
@@ -20,3 +20,8 @@ def edit_team_wizard(team_client):
         "team_name": choices.get("team_name"),
         "attribute_value": choices.get("attribute_value"),
     }
+
+
+def list_members_wizard(team_client, my):
+    choices = run_questionnaire(q_team(team_client, my))
+    return {"team_id": choices["team_id"]}

--- a/okdata/cli/data/output-format/team_members_config.json
+++ b/okdata/cli/data/output-format/team_members_config.json
@@ -1,0 +1,14 @@
+{
+  "Name": {
+    "name": "Name",
+    "key": "name"
+  },
+  "Username": {
+    "name": "Username",
+    "key": "username"
+  },
+  "Email": {
+    "name": "Email",
+    "key": "email"
+  }
+}


### PR DESCRIPTION
Add `teams list-members` command for listing the members of a team.

~~Depends on https://github.com/oslokommune/okdata-permission-api/pull/60, https://github.com/oslokommune/okdata-cli/pull/170, and https://github.com/oslokommune/okdata-sdk-python/pull/103 being released (and setup.py + requirements.txt being updated in this PR to reflect this).~~

~~Depends on https://github.com/oslokommune/okdata-cli/pull/171.~~