### PR TITLE
Update action and URL for `pubreg delete-client`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * The `pubreg list-keys` command now supports listing all client keys
   simultaneously across different clients.
+* Updated the action URL for the `pubreg delete-client` command. Updating to
+  this version is required for the command to continue working in the future.
 * Dataset title errors are caught earlier in the registration form.
 * Exiting a prompt by typing `Ctrl+D` no longer results in a stack trace.
 * Pygments is no longer a dependency.

--- a/okdata/cli/commands/pubreg/client.py
+++ b/okdata/cli/commands/pubreg/client.py
@@ -30,11 +30,11 @@ class PubregClient(SDK):
         return self.get(url).json()
 
     def delete_client(self, env, client_id, aws_account, aws_region):
-        url = f"{self.api_url}/clients/{env}/{client_id}"
+        url = f"{self.api_url}/clients/{env}/{client_id}/delete"
         log.info(f"Deleting client for: {url}")
-        return self.delete(
+        return self.post(
             url,
-            json={
+            data={
                 "aws_account": aws_account,
                 "aws_region": aws_region,
             },


### PR DESCRIPTION
Depends on ~~https://github.com/oslokommune/okdata-maskinporten-api/pull/124~~.