### PR TITLE
Make `datasets ls` take a single URI argument

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 * The `okdata status` command can now be set to watch the status of a dataset
   upload with the `--watch` option.
+* The `datasets ls` command now accepts a single optional URI argument that can
+  denote either a dataset, version, or edition:
+
+  - `okdata datasets ls {dataset_id}`
+  - `okdata datasets ls {dataset_id}/{version}`
+  - `okdata datasets ls {dataset_id}/{version}/{edition}`
 
 ## 3.1.0
 

--- a/tests/origocli/commands/datasets/datasets_test.py
+++ b/tests/origocli/commands/datasets/datasets_test.py
@@ -97,13 +97,13 @@ class TestDatasetsLs:
         assert not cmd.log.exception.called
 
     def test_version(self, mocker, output):
-        cmd = create_cmd(mocker, "ls", dataset["Id"], version["version"])
+        cmd = create_cmd(mocker, "ls", f'{dataset["Id"]}/{version["version"]}')
         cmd.handler()
         assert output_with_argument(output, cmd.sdk.get_editions.return_value)
 
     def test_edition(self, mocker, output):
         cmd = create_cmd(
-            mocker, "ls", dataset["Id"], version["version"], edition["edition"]
+            mocker, "ls", f'{dataset["Id"]}/{version["version"]}/{edition["edition"]}'
         )
         cmd.handler()
         assert output_with_argument(output, [edition])
@@ -201,3 +201,30 @@ class TestUtils:
         assert dataset_id == dataset["Id"]
         assert _version == version["version"]
         assert _edition == "new-edition"
+
+    def test_dataset_components_from_uri_no_resolve_1(self, mocker):
+        cmd = create_cmd(mocker, "ls")
+        dataset_id, _version, _edition = cmd._dataset_components_from_uri(
+            f"{dataset['Id']}", False, False
+        )
+        assert dataset_id == dataset["Id"]
+        assert _version is None
+        assert _edition is None
+
+    def test_dataset_components_from_uri_no_resolve_2(self, mocker):
+        cmd = create_cmd(mocker, "ls")
+        dataset_id, _version, _edition = cmd._dataset_components_from_uri(
+            f"{dataset['Id']}/{version['version']}", False, False
+        )
+        assert dataset_id == dataset["Id"]
+        assert _version == version["version"]
+        assert _edition is None
+
+    def test_dataset_components_from_uri_no_resolve_3(self, mocker):
+        cmd = create_cmd(mocker, "ls")
+        dataset_id, _version, _edition = cmd._dataset_components_from_uri(
+            f"{dataset['Id']}/{version['version']}/{edition['edition']}", False, False
+        )
+        assert dataset_id == dataset["Id"]
+        assert _version == version["version"]
+        assert _edition == edition["edition"]


### PR DESCRIPTION
Change the `datasets ls` syntax from `ls {dataset_id} {version} {edition}` to `ls {dataset_id/version/edition}`.

This has a few advantages:

* It matches the URI syntax used by the `datasets cp` command.

* It makes it easier to copy-paste version/edition IDs output by the CLI directly into the `ls` command, since the CLI always outputs on the dataset_id/version/edition format.

* It avoids the cryptic error that used to happen when attempting to use slashes in the dataset ID by mistake.