### PR TITLE
Fix timestamps for auto created editions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@
   - `okdata datasets ls {dataset_id}/{version}`
   - `okdata datasets ls {dataset_id}/{version}/{edition}`
 
+* Automatically created editions now get timestamped correctly. Previously it
+  was assumed that the user always operated in UTC+2.
+
 ## 3.1.0
 
 * Added support for Python 3.12.

--- a/okdata/cli/date.py
+++ b/okdata/cli/date.py
@@ -1,8 +1,0 @@
-from datetime import datetime
-
-DATE_SHORT_FORMAT = "%Y-%m-%d"
-DATE_METADATA_EDITION_FORMAT = "%Y-%m-%dT%H:%M:%S+02:00"
-
-
-def date_now():
-    return datetime.now()

--- a/requirements.txt
+++ b/requirements.txt
@@ -18,7 +18,7 @@ idna==3.3
     # via requests
 jsonschema==4.4.0
     # via okdata-sdk
-okdata-sdk==3.0.0
+okdata-sdk==3.1.0
     # via okdata-cli (setup.py)
 prettytable==3.2.0
     # via okdata-cli (setup.py)

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ setuptools.setup(
     install_requires=[
         "PrettyTable",
         "docopt",
-        "okdata-sdk>=3,<4",
+        "okdata-sdk>=3.1,<4",
         "questionary>=1.10.0,<2.0.0",
         "requests",
     ],

--- a/tests/origocli/commands/datasets/datasets_test.py
+++ b/tests/origocli/commands/datasets/datasets_test.py
@@ -63,7 +63,7 @@ def create_cmd(mocker, *args):
     cmd.sdk.get_editions.return_value = [edition, edition2]
     cmd.sdk.get_edition.return_value = edition
     cmd.sdk.get_latest_edition.return_value = edition
-    cmd.sdk.create_edition.return_value = new_edition
+    cmd.sdk.auto_create_edition.return_value = new_edition
     return cmd
 
 
@@ -144,12 +144,6 @@ class TestDatasetsCp:
 
 
 class TestUtils:
-    def test_auto_create_edition(self, mocker):
-        cmd = create_cmd(mocker, "ls")
-        assert (
-            cmd._auto_create_edition(dataset["Id"], version["version"]) == "new-edition"
-        )
-
     def test_dataset_components_from_uri_only_ds(self, mocker):
         cmd = create_cmd(mocker, "ls")
         dataset_id, _version, _edition = cmd._dataset_components_from_uri(dataset["Id"])


### PR DESCRIPTION
Fix the timestamps used in the names of automatically created editions. Previously it was assumed that the user always operated in UTC+2.