### PR TITLE
Improve error messages for non-existing datasets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 ## ?.?.? - Unreleased
 
 * Fixed extraneous newline printing in table output.
+* Improved error messages in the `datasets ls` and `datasets cp` commands when a
+  given dataset doesn't exist.
 
 ## 3.2.0 - 2024-01-15
 

--- a/okdata/cli/commands/datasets/datasets.py
+++ b/okdata/cli/commands/datasets/datasets.py
@@ -292,6 +292,10 @@ Options:{BASE_COMMAND_OPTIONS}
         parts = dataset_uri.split("/")
         dataset_id, version, edition = parts + [None] * (3 - len(parts))
 
+        # First verify that the dataset exists; `get_dataset` raises an error
+        # if not.
+        self.sdk.get_dataset(dataset_id)
+
         if auto_resolve:
             if not version:
                 version = self._get_latest_version(dataset_id)["version"]


### PR DESCRIPTION
Improve error messages in the `datasets ls` and `datasets cp` commands when a given dataset doesn't exist.

Previously one would get variably misleading messages depending on the degree of dataset/version/edition given. Now it gives a consistent error message that the dataset doesn't exist when it doesn't.