### PR TITLE
Add shorthand for granting a user all permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 ## ?.?.? - Unreleased
 
 * Added support for creating CSV->Delta dataset pipelines.
+* Added a shorthand for granting a user all permissions on a resource by not
+  specifying the `scope` parameter to the `permissions add` command, similar to
+  the way `permissions rm` works.
 * Fixed extraneous newline printing in table output.
 * Improved error messages in the `datasets ls` and `datasets cp` commands when a
   given dataset doesn't exist.

--- a/doc/permissions.md
+++ b/doc/permissions.md
@@ -85,7 +85,7 @@ This will list every permission associated with the dataset `my-dataset`.
 The commands for granting and revoking permissions to and from users, are:
 
 ```bash
-okdata permissions add <resource_name> <user> <scope>
+okdata permissions add <resource_name> <user> [<scope>]
 okdata permissions rm <resource_name> <user> [<scope>]
 ```
 
@@ -105,8 +105,8 @@ And to revoke that same permission:
 okdata permissions rm okdata:dataset:my-dataset janedoe okdata:dataset:read
 ```
 
-The `scope` parameter is optional for `rm`. When omitted, all permissions for
-the user on the given resource are revoked.
+The `scope` parameter is optional in both commands. When omitted, all
+permissions are granted or revoked for the user on the given resource.
 
 Both commands support additional `--team` and `--client` flags, which are used
 when the given user ID belongs to a team or a machine user, instead of a person

--- a/tests/origocli/commands/permissions_test.py
+++ b/tests/origocli/commands/permissions_test.py
@@ -110,17 +110,11 @@ def test_remove_user(mocker):
     cmd = make_cmd(mocker, "rm", "okdata:dataset:my-dataset", "foo")
     cmd.handler()
     cmd.client.update_permission.assert_called_once_with(
-        "okdata:dataset:my-dataset", "okdata:dataset:read", remove_users=[ANY]
+        "okdata:dataset:my-dataset", "__all__", remove_users=[ANY]
     )
     user = cmd.client.update_permission.mock_calls[0][2]["remove_users"][0]
     assert user.user_id == "foo"
     assert user.user_type == "user"
-
-
-def test_remove_user_nothing_to_remove(mocker):
-    cmd = make_cmd(mocker, "rm", "okdata:dataset:my-dataset", "foobar")
-    cmd.handler()
-    cmd.client.update_permission.assert_not_called()
 
 
 def test_remove_user_scope(mocker):
@@ -140,7 +134,7 @@ def test_remove_client(mocker):
     cmd = make_cmd(mocker, "rm", "okdata:dataset:my-dataset", "bar", "--client")
     cmd.handler()
     cmd.client.update_permission.assert_called_once_with(
-        "okdata:dataset:my-dataset", "okdata:dataset:read", remove_users=[ANY]
+        "okdata:dataset:my-dataset", "__all__", remove_users=[ANY]
     )
     user = cmd.client.update_permission.mock_calls[0][2]["remove_users"][0]
     assert user.user_id == "bar"
@@ -151,7 +145,7 @@ def test_remove_team(mocker):
     cmd = make_cmd(mocker, "rm", "okdata:dataset:my-dataset", "baz", "--team")
     cmd.handler()
     cmd.client.update_permission.assert_called_once_with(
-        "okdata:dataset:my-dataset", "okdata:dataset:read", remove_users=[ANY]
+        "okdata:dataset:my-dataset", "__all__", remove_users=[ANY]
     )
     user = cmd.client.update_permission.mock_calls[0][2]["remove_users"][0]
     assert user.user_id == "baz"


### PR DESCRIPTION
Add a shorthand for granting a user all permissions on a resource by not specifying the `scope` parameter to the `permissions add` command, similar to the way `permissions rm` works.