### PR TITLE
Add `okdata -e` and `okdata -v`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## ?.?.? - Unreleased
+
+* New commands `okdata -e` and `okdata -v` for printing the current environment
+  and the current version of okdata-cli, respectively.
+
 ## 4.1.0 - 2024-04-22
 
 * The minimum required version of `okdata-sdk` is now 3.1.1. This ensures

--- a/okdata/cli/__main__.py
+++ b/okdata/cli/__main__.py
@@ -16,8 +16,14 @@ from okdata.cli.commands.teams.teams import TeamsCommand
 
 def main():
     argv = sys.argv
-    if len(argv) < 2 or argv[1] == "help":
+    if len(argv) < 2:
         BaseCommand().help()
+        return
+    if argv[1] in ("-e", "--environment"):
+        BaseCommand().print_env()
+        return
+    if argv[1] in ("-v", "--version"):
+        BaseCommand().print_version()
         return
 
     command = get_command_class(argv)

--- a/okdata/cli/command.py
+++ b/okdata/cli/command.py
@@ -24,7 +24,9 @@ usage:
   okdata pubs [options]
   okdata status [options]
   okdata teams [options]
+  okdata -e | --environment
   okdata -h | --help
+  okdata -v | --version
 
 Commands available:
   datasets
@@ -118,6 +120,12 @@ Options:{BASE_COMMAND_OPTIONS}
 
     def help(self):
         print(self.__doc__, end="")
+
+    def print_env(self):
+        print(self.sdk.config.resolve_environment(None))
+
+    def print_version(self):
+        print(self.version)
 
     def print_error_response(self, response_body):
         if not isinstance(response_body, dict):


### PR DESCRIPTION
Add new commands `okdata -e` and `okdata -v` for printing the current environment and the current version of okdata-cli, respectively.