### PR TITLE
Robustify dataset/version/edition URI parsing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## ?.?.? - Unreleased
+
+* More robust dataset/version/edition URI parsing.
+
 ## 4.2.0 - 2024-06-18
 
 * New commands `okdata -e` and `okdata -v` for printing the current environment

--- a/okdata/cli/commands/datasets/datasets.py
+++ b/okdata/cli/commands/datasets/datasets.py
@@ -261,9 +261,9 @@ Options:{BASE_COMMAND_OPTIONS}
             )
 
     def _dataset_components_from_uri(
-        self, dataset_uri, create_edition=False, auto_resolve=True
+        self, uri, create_edition=False, auto_resolve=True
     ):
-        """Return an ID/version/edition tuple given a dataset URI.
+        """Return a dataset ID/version/edition tuple given a URI.
 
         Four different URI formats are supported:
 
@@ -289,8 +289,15 @@ Options:{BASE_COMMAND_OPTIONS}
 
         Otherwise `None` is returned for missing parts.
         """
-        parts = dataset_uri.split("/")
-        dataset_id, version, edition = parts + [None] * (3 - len(parts))
+        parts = uri.split("/")
+
+        try:
+            dataset_id, version, edition = parts + [None] * (3 - len(parts))
+        except ValueError:
+            sys.exit(
+                "URI must be on the format 'dataset_id', "
+                "'dataset_id/version', or 'dataset_id/version/edition'."
+            )
 
         # First verify that the dataset exists; `get_dataset` raises an error
         # if not.

--- a/tests/origocli/commands/datasets/datasets_test.py
+++ b/tests/origocli/commands/datasets/datasets_test.py
@@ -108,6 +108,11 @@ class TestDatasetsLs:
         cmd.handler()
         assert output_with_argument(output, [edition])
 
+    def test_invalid_uri(self, mocker, output):
+        cmd = create_cmd(mocker, "ls", "a/b/c/d/e")
+        with pytest.raises(SystemExit):
+            cmd.handler()
+
 
 class TestDatasetsCp:
     def test_copy_local_files(self, mocker):


### PR DESCRIPTION
Make the dataset/version/edition URI parsing more robust by not erroring out when too many components are passed.