### PR TITLE
Add event type datasets to the creation wizard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 * New command `datasets create-pipeline` for creating pipelines for existing
   datasets.
+* The dataset creation wizard can now create event type datasets. The database
+  dataset type has been removed.
 * More robust dataset/version/edition URI parsing.
 
 ## 4.2.0 - 2024-06-18

--- a/okdata/cli/commands/datasets/questions.py
+++ b/okdata/cli/commands/datasets/questions.py
@@ -35,7 +35,7 @@ def qs_create_dataset():
             "message": "Datakilde",
             "choices": [
                 Choice("Fil", "file"),
-                Choice("Database (krever eget databaseoppsett)", "database"),
+                Choice("Punktmålinger", "event"),
                 Choice("Ingen (datasettet skal ikke inneholde data direkte)", "none"),
             ],
         },


### PR DESCRIPTION
Make the dataset creation wizard able to create event type datasets.

Remove support for the obsolete database type.