### PR TITLE
Don't delete keys from SSM by default

### DIFF
--- a/okdata/cli/commands/pubs/questions.py
+++ b/okdata/cli/commands/pubs/questions.py
@@ -216,6 +216,7 @@ def q_delete_from_aws():
         "name": "delete_from_aws",
         "message": "Delete key from AWS Parameter Store?",
         "auto_enter": False,
+        "default": False,
     }
 
 


### PR DESCRIPTION
It was noted by a user that the default choice for all "do you want to delete stuff?" questions is "no", except for the question about whether you want to delete keys from Parameter Store.

Change that default to be in line with the others.