### PR TITLE
Streamline dataset listings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@
 * New commands `datasets delete-version`, `datasets delete-edition`, and
   `datasets delete-distribution` for deleting dataset versions, editions, and
   distributions respectively.
+* Streamlined output in the dataset listing commands.
+* New option `--verbose` for the `datasets ls` command which lists every
+  relevant metadata field for the listed datasets.
 
 ## 4.4.0 - 2025-05-14
 

--- a/okdata/cli/commands/datasets/datasets.py
+++ b/okdata/cli/commands/datasets/datasets.py
@@ -18,8 +18,8 @@ class DatasetsCommand(BaseCommand):
     __doc__ = f"""Oslo :: Datasets
 
 Usage:
-  okdata datasets ls [--filter=<filter> options]
-  okdata datasets ls <uri> [options]
+  okdata datasets ls [--filter=<filter> --verbose options]
+  okdata datasets ls <uri> [--verbose options]
   okdata datasets cp <source> <target> [options]
   okdata datasets create [options]
   okdata datasets create-version <dataset_id> [options]
@@ -33,7 +33,9 @@ Usage:
 Examples:
   okdata datasets ls
   okdata datasets ls --filter=bydelsfakta
+  okdata datasets ls --verbose
   okdata datasets ls my-dataset
+  okdata datasets ls my-dataset --verbose
   okdata datasets ls my-dataset/1
   okdata datasets ls my-dataset/1/20240101T102030
   okdata datasets ls my-dataset/1/20240101T102030 --format=json
@@ -99,7 +101,10 @@ Options:{BASE_COMMAND_OPTIONS}
     def datasets(self):
         self.log.info("Listing datasets")
         dataset_list = self.sdk.get_datasets(filter=self.opt("filter"))
-        out = create_output(self.opt("format"), "datasets_config.json")
+        out = create_output(
+            self.opt("format"),
+            f"datasets_config{'_verbose' if self.opt('verbose') else ''}.json",
+        )
         out.add_rows(dataset_list)
         self.print("Available datasets", out)
 
@@ -117,7 +122,12 @@ Options:{BASE_COMMAND_OPTIONS}
             )
             return
 
-        out = create_output(self.opt("format"), "datasets_dataset_config.json")
+        config = (
+            "datasets_config_verbose"
+            if self.opt("verbose")
+            else "datasets_dataset_config.json"
+        )
+        out = create_output(self.opt("format"), config)
         out.add_rows([dataset])
         self.print(f"Dataset: {dataset_id}", out)
 

--- a/okdata/cli/data/output-format/datasets_config.json
+++ b/okdata/cli/data/output-format/datasets_config.json
@@ -1,14 +1,18 @@
 {
-  "Id": {
-    "name": "Id",
+  "ID": {
+    "name": "ID",
     "key": "Id"
-  },
-  "Title": {
-    "name": "Title",
-    "key": "title"
   },
   "Publisher": {
     "name": "Publisher",
     "key": "publisher"
+  },
+  "Parent ID": {
+    "name": "Parent ID",
+    "key": "parent_id"
+  },
+  "Access rights": {
+    "name": "Access rights",
+    "key": "accessRights"
   }
 }

--- a/okdata/cli/data/output-format/datasets_config_verbose.json
+++ b/okdata/cli/data/output-format/datasets_config_verbose.json
@@ -1,4 +1,8 @@
 {
+  "ID": {
+    "name": "ID",
+    "key": "Id"
+  },
   "Title": {
     "name": "Title",
     "key": "title"
@@ -11,6 +15,10 @@
     "name": "Publisher",
     "key": "publisher"
   },
+  "Objective": {
+    "name": "Objective",
+    "key": "objective"
+  },
   "Parent ID": {
     "name": "Parent ID",
     "key": "parent_id"
@@ -19,8 +27,20 @@
     "name": "Access rights",
     "key": "accessRights"
   },
+  "Theme": {
+    "name": "Theme",
+    "key": "theme"
+  },
+  "Keywords": {
+    "name": "Keywords",
+    "key": "keywords"
+  },
+  "Frequency": {
+    "name": "Frequency",
+    "key": "frequency"
+  },
   "Contact point": {
-    "name": "Contact point",
+    "name": "Contact Point",
     "key": "contactPoint",
     "fields": [
       "name",

--- a/okdata/cli/data/output-format/datasets_dataset_version_config.json
+++ b/okdata/cli/data/output-format/datasets_dataset_version_config.json
@@ -1,6 +1,6 @@
 {
-  "Id": {
-    "name": "Id",
+  "ID": {
+    "name": "ID",
     "key": "Id"
   },
   "Edition": {

--- a/okdata/cli/data/output-format/datasets_dataset_version_edition_config.json
+++ b/okdata/cli/data/output-format/datasets_dataset_version_edition_config.json
@@ -1,6 +1,6 @@
 {
-  "Id": {
-    "name": "Id",
+  "ID": {
+    "name": "ID",
     "key": "Id"
   },
   "Edition": {

--- a/okdata/cli/data/output-format/datasets_dataset_version_edition_distributions_config.json
+++ b/okdata/cli/data/output-format/datasets_dataset_version_edition_distributions_config.json
@@ -1,6 +1,6 @@
 {
-  "Id": {
-    "name": "Id",
+  "ID": {
+    "name": "ID",
     "key": "Id"
   },
   "Filename": {

--- a/okdata/cli/data/output-format/datasets_dataset_versions_config.json
+++ b/okdata/cli/data/output-format/datasets_dataset_versions_config.json
@@ -1,6 +1,6 @@
 {
-  "Id": {
-    "name": "Id",
+  "ID": {
+    "name": "ID",
     "key": "Id"
   },
   "Version": {


### PR DESCRIPTION
Also add a new option `--verbose` for the `datasets ls` command which lists every relevant metadata field for the listed datasets.